### PR TITLE
Remove payload length from datagrams

### DIFF
--- a/receiver/moq_demuxer_downloader.js
+++ b/receiver/moq_demuxer_downloader.js
@@ -257,7 +257,7 @@ async function moqReceiveDatagramObjects (moqt) {
       if (moqObjHeader.type != MOQ_MESSAGE_OBJECT_DATAGRAM) {
         throw new Error(`Received via datagram a non properly encoded object ${JSON.stringify(moqObjHeader)}`)
       }
-      await readAndSendPayload(readableStream, moqObjHeader.extensionHeaders, moqObjHeader.payloadLength)
+      await readAndSendPayload(readableStream, moqObjHeader.extensionHeaders)
     }
   }
 

--- a/utils/buffer_utils.js
+++ b/utils/buffer_utils.js
@@ -58,15 +58,15 @@ export async function readUntilEof (readableStream, blockSize) {
     }
   }
   // Concatenate received data
-  const payload = new Uint8Array(totalLength)
+  const uint8Buffer = new Uint8Array(totalLength)
   let pos = 0
   for (const element of chunkArray) {
     const uint8view = new Uint8Array(element, 0, element.byteLength)
-    payload.set(uint8view, pos)
+    uint8Buffer.set(uint8view, pos)
     pos += element.byteLength
   }
 
-  return payload
+  return uint8Buffer
 }
 
 export async function buffRead (readableStream, size) {

--- a/utils/moqt.js
+++ b/utils/moqt.js
@@ -628,7 +628,6 @@ function moqCreateObjectPerDatagramBytes (trackAlias, groupSeq, objSeq, publishe
     msg.push(moqCreateExtensionHeaders(extensionHeaders)); // Extension headers
   }
   if (data != undefined && data.byteLength > 0) {
-    msg.push(numberToVarInt(data.byteLength))
     msg.push(data)
   } else {
     msg.push(numberToVarInt(0))
@@ -667,11 +666,7 @@ export async function moqParseObjectHeader (readerStream) {
     const objSeq = await varIntToNumberOrThrow(readerStream);
     const publisherPriority = await moqByteReadOrThrow(readerStream);
     const extensionHeaders = await moqReadExtensionHeaders(readerStream)
-    const payloadLength = await varIntToNumberOrThrow(readerStream);
-    ret = {type, trackAlias, groupSeq, objSeq, publisherPriority, extensionHeaders, payloadLength}
-    if (payloadLength == 0) {
-      ret.status = await varIntToNumberOrThrow(readerStream)
-    }
+    ret = {type, trackAlias, groupSeq, objSeq, publisherPriority, extensionHeaders}
   }
   else if (type == MOQ_MESSAGE_STREAM_HEADER_SUBGROUP) {
     const trackAlias = await varIntToNumberOrThrow(readerStream)


### PR DESCRIPTION
- Draft 8 has editorial issues in this section: https://www.ietf.org/archive/id/draft-ietf-moq-transport-08.html#name-object-datagram

The table indicate we should add `Object Payload Length (i)` 

```
OBJECT_DATAGRAM {
  Track Alias (i),
  Group ID (i),
  Object ID (i),
  Publisher Priority (8),
  Extension Count (i),
  [Extension headers (...)],
  Object Payload Length (i),
  [Object Status (i)],
  Object Payload (..),
}
```

And the text below says "There is no explicit length field. The entirety of the transport datagram following Publisher Priority contains the Object Payload."

In a meeting between Suhas, Alan, and Jordi we agreed that the right interpretation is the text