### PR TITLE
fixed open streams counter and defaulted audio mapping to subgroup per frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Note: `opus.frameDuration` setting helps keeping encoding latency low
 - **Creates a Unidirectional (encoder -> server) QUIC stream per every frame** (video and audio)
 - Receives audio and video chunks from `a_encoder.ts` and `v_encoder.ts`
 - It uses sendOrder to establish send priority. We use incremental counter (so new is higher priority than old), and we also increase audio priority over video (by adding an offset)
-- It keeps number of inflight requests always below configured value `maxInFlightRequest`
+- It keeps the per-track send queue below the configured `maxInFlightRequests` (objects waiting to be written are dropped once the queue is full). Two stats are reported per track: `numQueued` (objects waiting in the send queue) and `numOpenStreams` (open QUIC subgroup streams)
 
 ## Player
 

--- a/demo/encoder/index.html
+++ b/demo/encoder/index.html
@@ -124,16 +124,28 @@ LICENSE file in the root directory of this source tree.
                     <div class="clear"></div>
                     <label>Full track names (based on namespace and track name):<input id="fullTrackNames" type="text" value="-" size="64" readonly></label>
                     <div class="clear"></div>
-                    <label>Max inflight audio requests:<input id="maxInflightAudioRequests" type="text" value="60"></label>
-                    <div class="clear"></div>
-                    <label>Max inflight video requests:<input id="maxInflightVideoRequests" type="text" value="39"></label>
-                    <div class="clear"></div>
                     <label>Token (type = out of band):<input id="authInfo" type="text" value="secret" disabled></label>
                     <label>Active: <input type="checkbox" id="useAuthToken"></label>
                     <div class="clear"></div>
                     <label>MOQ video packager:<select id="moqVideoQuicMapping"></select></label>
                     <label>MOQ audio packager:<select id="moqAudioQuicMapping"></select></label>
                     <div class="clear"></div>
+                    <div class="boxed">
+                        <h3>Queue limits</h3>
+                        <div class="clear"></div>
+                        <label>Max send-queue audio objects:<input id="maxInflightAudioRequests" type="text" value="20"></label>
+                        <div class="clear"></div>
+                        <label>Max send-queue video objects:<input id="maxInflightVideoRequests" type="text" value="10"></label>
+                        <div class="clear"></div>
+                    </div>
+                    <div class="boxed">
+                        <h3>QUIC stream limits</h3>
+                        <div class="clear"></div>
+                        <label>Max QUIC streams for audio:<input id="maxQUICStreamsAudio" type="text" value="60"></label>
+                        <div class="clear"></div>
+                        <label>Max QUIC streams for video:<input id="maxQUICStreamsVideo" type="text" value="39"></label>
+                        <div class="clear"></div>
+                    </div>
                 </div>
                 <button id="btnStart" type="button">Start</button>
                 <button id="btnStop" type="button" disabled>Stop</button>
@@ -185,13 +197,15 @@ LICENSE file in the root directory of this source tree.
         <video height="50%" id="vPreview" autoplay muted></video>
     </div>
 
-    <!-- Inflight requests timeline (last 60s) -->
+    <!-- Send queue / open streams timeline (last 60s) -->
     <div class="boxed">
-        <h2>Inflight requests timeline (last 60s)</h2>
+        <h2>Send queue / open streams timeline (last 60s)</h2>
         <canvas id="inflightTimeline" style="display:block; width:100%; height:200px; border:1px solid"></canvas>
         <div class="styleform">
-            <label><span style="display:inline-block;width:18px;height:3px;background:#d62728;vertical-align:middle"></span> Audio inflight</label>
-            <label><span style="display:inline-block;width:18px;height:3px;background:#1f77b4;vertical-align:middle"></span> Video inflight</label>
+            <label><span style="display:inline-block;width:18px;height:3px;background:#d62728;vertical-align:middle"></span> Audio queued</label>
+            <label><span style="display:inline-block;width:18px;height:3px;background:#1f77b4;vertical-align:middle"></span> Video queued</label>
+            <label><span style="display:inline-block;width:18px;height:3px;background:#d62728;vertical-align:middle;border-top:2px dashed #d62728;height:0"></span> Audio open streams (dashed)</label>
+            <label><span style="display:inline-block;width:18px;height:3px;background:#1f77b4;vertical-align:middle;border-top:2px dashed #1f77b4;height:0"></span> Video open streams (dashed)</label>
             <label><span style="display:inline-block;width:6px;height:14px;background:#d62728;opacity:0.45;vertical-align:middle"></span> Audio packet loss</label>
             <label><span style="display:inline-block;width:6px;height:14px;background:#1f77b4;opacity:0.45;vertical-align:middle"></span> Video packet loss</label>
         </div>
@@ -264,13 +278,19 @@ LICENSE file in the root directory of this source tree.
         <div id="tabMuxer" class="boxed tab-panel">
             <h2>Muxer sender</h2>
             <div>
-                <h3>Inflight</h3>
+                <h3>Send queue / open streams</h3>
                 <div class="styleform">
                     <form>
-                        <label>Inflight audio requests:<input id="uploadStatsAudioInflight" type="text" value=""
+                        <label>Queued audio objects:<input id="uploadStatsAudioQueued" type="text" value=""
                                 readonly></label>
                         <div class="clear"></div>
-                        <label>Inflight video requests:<input id="uploadStatsVideoInflight" type="text" value=""
+                        <label>Queued video objects:<input id="uploadStatsVideoQueued" type="text" value=""
+                                readonly></label>
+                        <div class="clear"></div>
+                        <label>Open audio streams:<input id="uploadStatsAudioStreams" type="text" value=""
+                                readonly></label>
+                        <div class="clear"></div>
+                        <label>Open video streams:<input id="uploadStatsVideoStreams" type="text" value=""
                                 readonly></label>
                         <div class="clear"></div>
                     </form>
@@ -420,7 +440,8 @@ LICENSE file in the root directory of this source tree.
             "audio": {
                 namespace: ["vc"],
                 name: "audio0",
-                maxInFlightRequests: 100,
+                maxInFlightRequests: 20,
+                maxOpenStreams: 60,
                 isHipri: true,
                 authInfo: "secret",
                 moqMapping: MOQ_MAPPING_SUBGROUP_PER_GROUP,
@@ -428,7 +449,8 @@ LICENSE file in the root directory of this source tree.
             "video": {
                 namespace: ["vc"],
                 name: "video0",
-                maxInFlightRequests: 50,
+                maxInFlightRequests: 10,
+                maxOpenStreams: 39,
                 isHipri: false,
                 authInfo: "secret",
                 moqMapping: MOQ_MAPPING_SUBGROUP_PER_GROUP,
@@ -443,11 +465,12 @@ LICENSE file in the root directory of this source tree.
     let aEncoderWorker = null;
     let muxerSenderWorker = null;
 
-    // Inflight requests timeline
+    // Send queue / open streams timeline
     const TIMELINE_WINDOW_MS = 60000; // 60s shown on X axis
     const TIMELINE_AUDIO_COLOR = '#d62728';
     const TIMELINE_VIDEO_COLOR = '#1f77b4';
-    let timelineSamples = []; // { tMs, audio, video } relative to session start
+    // { tMs, audioQueued, videoQueued, audioStreams, videoStreams } relative to session start
+    let timelineSamples = [];
     let timelineDrops = [];   // { tMs, mediaType, cum } one entry per dropped packet
     let dropCum = { audio: 0, video: 0 }; // running session totals of dropped packets
     let timelineStartMs = -1; // Date.now() when start was pressed
@@ -462,7 +485,9 @@ LICENSE file in the root directory of this source tree.
         timelineStartMs = Date.now();
         const maxV = parseInt(document.getElementById('maxInflightVideoRequests').value) || 0;
         const maxA = parseInt(document.getElementById('maxInflightAudioRequests').value) || 0;
-        timelineYMax = Math.max(maxV, maxA, 1);
+        const maxStreamsV = parseInt(document.getElementById('maxQUICStreamsVideo').value) || 0;
+        const maxStreamsA = parseInt(document.getElementById('maxQUICStreamsAudio').value) || 0;
+        timelineYMax = Math.max(maxV, maxA, maxStreamsV, maxStreamsA, 1);
         if (timelineAnimFrame === null) {
             timelineAnimFrame = requestAnimationFrame(drawTimeline);
         }
@@ -475,11 +500,14 @@ LICENSE file in the root directory of this source tree.
         }
     }
 
-    function addTimelineSample(audioInflight, videoInflight) {
+    function addTimelineSample(audioQueued, videoQueued, audioStreams, videoStreams) {
         if (timelineStartMs < 0) {
             return;
         }
-        timelineSamples.push({ tMs: Date.now() - timelineStartMs, audio: audioInflight, video: videoInflight });
+        timelineSamples.push({
+            tMs: Date.now() - timelineStartMs,
+            audioQueued, videoQueued, audioStreams, videoStreams,
+        });
     }
 
     function addTimelineDrop(mediaType) {
@@ -508,9 +536,10 @@ LICENSE file in the root directory of this source tree.
         }
     }
 
-    function drawTimelineSeries(ctx, w, h, nowMs, key, color) {
+    function drawTimelineSeries(ctx, w, h, nowMs, key, color, dashed) {
         ctx.strokeStyle = color;
         ctx.lineWidth = 2;
+        ctx.setLineDash(dashed ? [5, 4] : []);
         ctx.beginPath();
         let started = false;
         for (let i = 0; i < timelineSamples.length; i++) {
@@ -526,6 +555,7 @@ LICENSE file in the root directory of this source tree.
             }
         }
         ctx.stroke();
+        ctx.setLineDash([]);
     }
 
     function drawTimeline() {
@@ -595,8 +625,11 @@ LICENSE file in the root directory of this source tree.
         // Packet-loss bars (one per dropped packet, height = cumulative loss for its media type)
         drawTimelineDrops(ctx, w, h, nowMs, rightYMax);
 
-        drawTimelineSeries(ctx, w, h, nowMs, 'audio', TIMELINE_AUDIO_COLOR);
-        drawTimelineSeries(ctx, w, h, nowMs, 'video', TIMELINE_VIDEO_COLOR);
+        // Queued objects (solid) and open streams (dashed) per media type
+        drawTimelineSeries(ctx, w, h, nowMs, 'audioQueued', TIMELINE_AUDIO_COLOR, false);
+        drawTimelineSeries(ctx, w, h, nowMs, 'videoQueued', TIMELINE_VIDEO_COLOR, false);
+        drawTimelineSeries(ctx, w, h, nowMs, 'audioStreams', TIMELINE_AUDIO_COLOR, true);
+        drawTimelineSeries(ctx, w, h, nowMs, 'videoStreams', TIMELINE_VIDEO_COLOR, true);
 
         timelineAnimFrame = requestAnimationFrame(drawTimeline);
     }
@@ -620,8 +653,10 @@ LICENSE file in the root directory of this source tree.
     }
 
     function clearUI() {
-        document.getElementById('uploadStatsAudioInflight').value = "0";
-        document.getElementById('uploadStatsVideoInflight').value = "0";
+        document.getElementById('uploadStatsAudioQueued').value = "0";
+        document.getElementById('uploadStatsVideoQueued').value = "0";
+        document.getElementById('uploadStatsAudioStreams').value = "0";
+        document.getElementById('uploadStatsVideoStreams').value = "0";
 
         document.getElementById('firstVts').value = "";
         document.getElementById('firstAts').value = "";
@@ -956,7 +991,7 @@ LICENSE file in the root directory of this source tree.
 
     function initMOQMappingModesUI(selectElement) {
         initMOQMappingModeUI(document.getElementById('moqVideoQuicMapping'), MOQ_MAPPING_SUBGROUP_PER_GROUP, "video");
-        initMOQMappingModeUI(document.getElementById('moqAudioQuicMapping'), MOQ_MAPPING_OBJECT_PER_DATAGRAM, "audio");
+        initMOQMappingModeUI(document.getElementById('moqAudioQuicMapping'), MOQ_MAPPING_SUBGROUP_PER_GROUP, "audio");
     }
 
     function initMOQMappingModeUI(selectElement, moqMappingSelected, mediaType) {
@@ -1216,7 +1251,7 @@ LICENSE file in the root directory of this source tree.
             muxerSenderWorker.postMessage({ type: "chunk", mediaType: "audio", firstFrameClkms, compensatedTs, seqId: seqId, chunk: chunk, metadata: metadata, timebase, sampleFreq, numChannels, codec});
             // CHUNKS STATS
         } else if (e.data.type === "sendstats") {
-            updateUploadStats(e.data.inFlightReq);
+            updateUploadStats(e.data.queuedReq, e.data.openStreamsReq);
 
             // UNKNOWN
         } else {
@@ -1224,11 +1259,13 @@ LICENSE file in the root directory of this source tree.
         }
     }
 
-    function updateUploadStats(inFlightReq) {
-        document.getElementById('uploadStatsAudioInflight').value = `${inFlightReq["audio"]} (${returnMax('inFlightAudioReqNum', inFlightReq["audio"])})`;
-        document.getElementById('uploadStatsVideoInflight').value = `${inFlightReq["video"]} (${returnMax('inFlightVideoReqNum', inFlightReq["video"])})`;
+    function updateUploadStats(queuedReq, openStreamsReq) {
+        document.getElementById('uploadStatsAudioQueued').value = `${queuedReq["audio"]} (${returnMax('queuedAudioReqNum', queuedReq["audio"])})`;
+        document.getElementById('uploadStatsVideoQueued').value = `${queuedReq["video"]} (${returnMax('queuedVideoReqNum', queuedReq["video"])})`;
+        document.getElementById('uploadStatsAudioStreams').value = `${openStreamsReq["audio"]} (${returnMax('streamsAudioReqNum', openStreamsReq["audio"])})`;
+        document.getElementById('uploadStatsVideoStreams').value = `${openStreamsReq["video"]} (${returnMax('streamsVideoReqNum', openStreamsReq["video"])})`;
 
-        addTimelineSample(inFlightReq["audio"], inFlightReq["video"]);
+        addTimelineSample(queuedReq["audio"], queuedReq["video"], openStreamsReq["audio"], openStreamsReq["video"]);
     }
 
     function updateDroppedFrame(droppedFrameData) {
@@ -1392,6 +1429,7 @@ LICENSE file in the root directory of this source tree.
         muxerSenderConfig.moqTracks["video"].namespace = document.getElementById('namespace').value.split("/");
         muxerSenderConfig.moqTracks["video"].name = MIgetTrackName(document.getElementById('trackName').value, false);
         muxerSenderConfig.moqTracks["video"].maxInFlightRequests = parseInt(document.getElementById('maxInflightVideoRequests').value);
+        muxerSenderConfig.moqTracks["video"].maxOpenStreams = parseInt(document.getElementById('maxQUICStreamsVideo').value);
         muxerSenderConfig.moqTracks["video"].moqMapping = document.getElementById('moqVideoQuicMapping').value;
         if (document.getElementById('authInfo').disabled) {
             muxerSenderConfig.moqTracks["video"].authInfo = ""
@@ -1401,6 +1439,7 @@ LICENSE file in the root directory of this source tree.
         muxerSenderConfig.moqTracks["audio"].namespace = document.getElementById('namespace').value.split("/");
         muxerSenderConfig.moqTracks["audio"].name = MIgetTrackName(document.getElementById('trackName').value, true);
         muxerSenderConfig.moqTracks["audio"].maxInFlightRequests = parseInt(document.getElementById('maxInflightAudioRequests').value);
+        muxerSenderConfig.moqTracks["audio"].maxOpenStreams = parseInt(document.getElementById('maxQUICStreamsAudio').value);
         muxerSenderConfig.moqTracks["audio"].authInfo = document.getElementById('authInfo').value;
         muxerSenderConfig.moqTracks["audio"].moqMapping = document.getElementById('moqAudioQuicMapping').value;
         if (document.getElementById('authInfo').disabled) {

--- a/src/moq/README.md
+++ b/src/moq/README.md
@@ -113,7 +113,7 @@ sequenceDiagram
   participant Relay
   App->>Moq: init(url, { alpnVersion })
   App->>Moq: await setup()
-  App->>Moq: await addTrack(ns, name, maxInFlight, auth, mapping)
+  App->>Moq: await addTrack(ns, name, maxQueuedObjects, auth, mapping)
   Moq->>Relay: PUBLISH
   Relay-->>Moq: PUBLISH_OK (Forward State 0 or 1)
   Moq-->>App: Track
@@ -188,15 +188,18 @@ enable the idle keep-alive loop. Moves the session to `Running`.
 addTrack(
   namespace: string[],
   name: string,
-  maxInFlightRequests: number,
+  maxQueuedObjects: number,
+  maxOpenStreams: number,
   authInfo: string | undefined,
   moqMapping: MoqMapping,
 ): Promise<Track>
 ```
 Publish a track: sends `PUBLISH` and resolves with a [`Track`](#track) once the
 peer replies `PUBLISH_OK`. `namespace` is a tuple (array) of name segments;
-`name` is the track name. `maxInFlightRequests` bounds the per-track send queue
-(`<= 0` means unbounded). `authInfo` is an optional auth token string.
+`name` is the track name. `maxQueuedObjects` bounds the per-track send queue and
+`maxOpenStreams` bounds the concurrent open subgroup streams — a new group is
+dropped while that many streams are still open (both `<= 0` mean unbounded).
+`authInfo` is an optional auth token string.
 
 ```ts
 subscribe(
@@ -232,7 +235,8 @@ open subgroup stream(s), and Forward State.
 | `trackAlias` | `number` | Numeric alias used on the wire for objects. |
 | `publisherRequestId` | `number` | Request id of the originating `PUBLISH`. |
 | `authInfo` | `string \| undefined` | Auth token, if any. |
-| `maxInFlightRequests` | `number` | Send-queue cap. |
+| `maxQueuedObjects` | `number` | Send-queue cap (objects dropped once the queue reaches this). |
+| `maxOpenStreams` | `number` | Open subgroup-stream cap (a new group is dropped while this many streams are still open). |
 | `moqMapping` | `MoqMapping` | Object→QUIC mapping. |
 | `subscribers` | `Subscriber[]` | Active downstream subscriber/forward entries (mostly internal). |
 
@@ -255,7 +259,9 @@ headers (e.g. MoQMI metadata). `callback` fires once the object is written.
 The returned object's `status` is **`dropped`** (nothing sent) when:
 - the track is `closed`,
 - the subscription is **not being forwarded** (Forward State 0 / no subscriber),
-- the pending queue is already at `maxInFlightRequests`.
+- the pending send queue is already at `maxQueuedObjects`,
+- starting a new group would exceed `maxOpenStreams` (subgroup mapping) — the
+  whole group is then dropped until a later group finds room.
 
 ```ts
 getInfo(): TrackInfo
@@ -371,7 +377,8 @@ type ObjectCallback = (
 interface TrackInfo {
   namespace: string[]; name: string; trackAlias: number; moqMapping: MoqMapping;
   numSubscribers: number;   // reflects Forward State (0 or 1 for a PUBLISH track)
-  numInFlight: number;      // queued objects
+  numQueued: number;        // objects waiting in the send queue (not yet written)
+  numOpenStreams: number;   // subgroup streams created but not yet closed (0 for datagram)
   currentGroup: number; currentObject: number;
 }
 interface SubscriptionInfo { namespace: string[]; name: string; subscribeRequestId: number; trackAlias: number }
@@ -397,7 +404,8 @@ await moq.setup({ everyMs: 5000 }); // optional keep-alive while idle
 const video = await moq.addTrack(
   ['vc', 'room42'],            // namespace tuple
   'video0',                    // track name
-  100,                         // max in-flight objects
+  10,                          // max queued objects
+  39,                          // max open subgroup streams
   undefined,                   // authInfo
   MoqMapping.SubgroupPerGroup, // video → one stream per group
 );
@@ -457,7 +465,7 @@ const moq = new Moq();
 moq.init(url, { alpnVersion: 'moqt-16' });
 await moq.setup();
 
-const track = await moq.addTrack(ns, 'data0', 0, undefined, MoqMapping.ObjectPerDatagram);
+const track = await moq.addTrack(ns, 'data0', 0, 0, undefined, MoqMapping.ObjectPerDatagram);
 await moq.subscribe(ns, 'data0', undefined, (r, ext, len) => true);
 
 track.sendObject(new TextEncoder().encode('hello'), { priority: 128 });

--- a/src/moq/moq.ts
+++ b/src/moq/moq.ts
@@ -17,7 +17,7 @@ LICENSE file in the root directory of this source tree.
 //   // WT-Available-Protocols (draft-16), so setup() carries no version.
 //
 //   // Publish:
-//   const track = await moq.addTrack(ns, name, maxInFlight, auth, mapping);
+//   const track = await moq.addTrack(ns, name, maxQueuedObjects, maxOpenStreams, auth, mapping);
 //   const obj = track.sendObject(bytes, { priority }, extHeaders, () => {});  // new group
 //   track.sendObject(moreBytes);                                              // same group
 //   obj.getInfo();   // { objId, groupId, status }
@@ -115,7 +115,10 @@ export interface TrackInfo {
   trackAlias: number;
   moqMapping: MoqMapping;
   numSubscribers: number;
-  numInFlight: number;
+  // Objects waiting in the per-track send queue (not yet written to a stream).
+  numQueued: number;
+  // Open QUIC subgroup streams: created but not yet closed (0 for datagram).
+  numOpenStreams: number;
   currentGroup: number;
   currentObject: number;
 }
@@ -229,7 +232,11 @@ export class Track {
   readonly trackAlias: number;
   readonly publisherRequestId: number;
   readonly authInfo: string | undefined;
-  readonly maxInFlightRequests: number;
+  // Send-queue cap: objects are dropped once `queue.length` reaches this.
+  readonly maxQueuedObjects: number;
+  // Open-stream cap (subgroup mapping): a new group is dropped (its stream is
+  // not opened) while `openStreamCount` is at this limit. 0 / unset = unbounded.
+  readonly maxOpenStreams: number;
   readonly moqMapping: MoqMapping;
 
   subscribers: Subscriber[] = [];
@@ -254,9 +261,16 @@ export class Track {
   private currentGroupPriority = MOQ_PUBLISHER_PRIORITY_BASE_DEFAULT;
 
   // Open subgroup stream writer keyed by group id (one at a time in practice).
-  private streams = new Map<number, WritableStreamDefaultWriter<Uint8Array>>();
+  private openStreams = new Map<number, WritableStreamDefaultWriter<Uint8Array>>();
   // Last object id written per group (used to send the end-of-group marker).
   private groupLastObj = new Map<number, number>();
+  // Number of subgroup streams created but not yet finished closing. Counts the
+  // current group's stream plus any whose end-of-group close is still settling,
+  // so it reflects the QUIC streams genuinely open against the relay.
+  private openStreamCount = 0;
+  // Set when a new group was dropped by the open-stream cap, so the rest of that
+  // group's objects (deltas) are dropped too until the next group is accepted.
+  private skipDeltasUntilNewGroup = false;
 
   constructor(
     moq: Moq,
@@ -264,7 +278,8 @@ export class Track {
     name: string,
     trackAlias: number,
     publisherRequestId: number,
-    maxInFlightRequests: number,
+    maxQueuedObjects: number,
+    maxOpenStreams: number,
     authInfo: string | undefined,
     moqMapping: MoqMapping,
   ) {
@@ -273,8 +288,10 @@ export class Track {
     this.name = name;
     this.trackAlias = trackAlias;
     this.publisherRequestId = publisherRequestId;
-    this.maxInFlightRequests =
-      maxInFlightRequests > 0 ? maxInFlightRequests : Number.MAX_SAFE_INTEGER;
+    this.maxQueuedObjects =
+      maxQueuedObjects > 0 ? maxQueuedObjects : Number.MAX_SAFE_INTEGER;
+    this.maxOpenStreams =
+      maxOpenStreams > 0 ? maxOpenStreams : Number.MAX_SAFE_INTEGER;
     this.authInfo = authInfo;
     this.moqMapping = moqMapping;
   }
@@ -286,8 +303,10 @@ export class Track {
    * (e.g. MoQMI media metadata). `callback` fires once the object is written.
    *
    * Returns an `ObjData` handle. Objects are dropped (status `dropped`) when the
-   * subscription is not being forwarded (Forward State 0 / no subscriber), or
-   * when the pending queue is already at `maxInFlightRequests`.
+   * subscription is not being forwarded (Forward State 0 / no subscriber), when
+   * the pending send queue is already at `maxQueuedObjects`, or (subgroup
+   * mapping) when starting a new group would exceed `maxOpenStreams` — in which
+   * case the whole group is dropped until a later group finds room.
    */
   sendObject(
     data: BufferSource | undefined,
@@ -323,8 +342,26 @@ export class Track {
       this.resumeNeedsNewGroup = false;
     }
 
-    // Drop when the pending queue is full.
-    if (this.queue.length >= this.maxInFlightRequests) {
+    // Open-stream cap (subgroup mapping): refuse to start a new group while too
+    // many subgroup streams are still open, and drop the rest of a group whose
+    // start was refused. Datagram mapping opens no streams, so it is exempt.
+    if (this.moqMapping === MoqMapping.SubgroupPerGroup) {
+      if (newGroup) {
+        this.skipDeltasUntilNewGroup = this.openStreamCount >= this.maxOpenStreams;
+      }
+      if (this.skipDeltasUntilNewGroup) {
+        return new ObjData(
+          this,
+          this.currentGroupSeq,
+          this.currentObjectSeq,
+          'dropped',
+          this.currentGroupPriority,
+        );
+      }
+    }
+
+    // Drop when the pending send queue is full.
+    if (this.queue.length >= this.maxQueuedObjects) {
       return new ObjData(
         this,
         this.currentGroupSeq,
@@ -362,7 +399,8 @@ export class Track {
       trackAlias: this.trackAlias,
       moqMapping: this.moqMapping,
       numSubscribers: this.subscribers.length,
-      numInFlight: this.queue.length,
+      numQueued: this.queue.length,
+      numOpenStreams: this.openStreamCount,
       currentGroup: this.currentGroupSeq,
       currentObject: this.currentObjectSeq,
     };
@@ -382,7 +420,7 @@ export class Track {
     this.queue = [];
 
     // Close every open subgroup stream with an end-of-group object.
-    for (const [groupId, writer] of this.streams) {
+    for (const [groupId, writer] of this.openStreams) {
       const lastObj = this.groupLastObj.get(groupId) ?? 0;
       try {
         await moqSendObjectEndOfGroupToWriter(writer, lastObj + 1, [], true);
@@ -390,7 +428,8 @@ export class Track {
         // Best-effort on teardown.
       }
     }
-    this.streams.clear();
+    this.openStreams.clear();
+    this.openStreamCount = 0;
 
     try {
       await moqSendPublishDone(
@@ -430,15 +469,17 @@ export class Track {
   // Reset and forget all open subgroup streams (best-effort). Used when
   // forwarding stops, so stale streams don't linger to be STOP_SENDING'd.
   private async resetStreams(): Promise<void> {
-    const streams = this.streams;
-    this.streams = new Map();
+    const streams = this.openStreams;
+    this.openStreams = new Map();
     this.groupLastObj.clear();
+    this.skipDeltasUntilNewGroup = false;
     for (const writer of streams.values()) {
       try {
         await writer.abort('forward paused');
       } catch {
         // Best-effort: the relay may have already reset the stream.
       }
+      this.openStreamCount = Math.max(0, this.openStreamCount - 1);
     }
   }
 
@@ -548,30 +589,27 @@ export class Track {
       throw new Error(`Unexpected MOQ - QUIC mapping: ${this.moqMapping}`);
     }
 
-    // Close any open stream from a previous group (the group rolled). The
-    // end-of-group object is one past the last object on this single per-group
-    // stream, i.e. Object ID Delta 0. This is best-effort: the relay may have
-    // already reset the stream (e.g. after the subscriber went away), so an
-    // error here must not wedge the track — always drop the stream from the map.
-    for (const [groupId, writer] of this.streams) {
+    // Close any open stream from a previous group (the group rolled). The close
+    // runs in the background (closeStream) so a slow end-of-group + FIN does not
+    // block the drain; the stream stays counted in openStreamCount until it
+    // settles, which is what the open-stream cap throttles against.
+    for (const [groupId, writer] of this.openStreams) {
       if (groupId !== obj.groupId) {
-        try {
-          await moqSendObjectEndOfGroupToWriter(writer, 0, [], true);
-        } catch {
-          // Stream was likely stopped/reset by the peer; just forget it.
-        }
-        this.streams.delete(groupId);
+        this.openStreams.delete(groupId);
         this.groupLastObj.delete(groupId);
+        this.closeStream(writer);
       }
     }
 
-    // Open a stream for this group on demand, writing the subgroup header.
-    let writer = this.streams.get(obj.groupId);
+    // Open a stream for this group on demand, writing the subgroup header. The
+    // open-stream cap already gated this in sendObject, so by here there is room.
+    let writer = this.openStreams.get(obj.groupId);
     if (writer === undefined) {
       // Use the group priority directly as the WebTransport stream send order.
       const uniStream = await this.moq._wt().createUnidirectionalStream({ sendOrder: obj.priority });
       writer = uniStream.getWriter();
-      this.streams.set(obj.groupId, writer);
+      this.openStreams.set(obj.groupId, writer);
+      this.openStreamCount++;
       await moqSendSubgroupHeader(writer, this.trackAlias, obj.groupId, obj.priority);
     }
 
@@ -582,11 +620,25 @@ export class Track {
       // The stream was stopped/reset (e.g. the relay sent STOP_SENDING when the
       // subscriber left). Abandon it so we don't keep writing to a dead stream;
       // a later object (after forwarding resumes) opens a fresh one.
-      this.streams.delete(obj.groupId);
+      this.openStreams.delete(obj.groupId);
       this.groupLastObj.delete(obj.groupId);
+      this.openStreamCount = Math.max(0, this.openStreamCount - 1);
       throw err;
     }
     this.groupLastObj.set(obj.groupId, obj.objId);
+  }
+
+  // Close a rolled-off subgroup stream in the background: send end-of-group +
+  // FIN (Object ID Delta 0), then drop it from openStreamCount once the close
+  // settles. Best-effort — the relay may have already reset the stream.
+  private closeStream(writer: WritableStreamDefaultWriter<Uint8Array>): void {
+    void moqSendObjectEndOfGroupToWriter(writer, 0, [], true)
+      .catch(() => {
+        // Stream was likely stopped/reset by the peer; just forget it.
+      })
+      .finally(() => {
+        this.openStreamCount = Math.max(0, this.openStreamCount - 1);
+      });
   }
 }
 
@@ -769,7 +821,8 @@ export class Moq {
   async addTrack(
     namespace: string[],
     name: string,
-    maxInFlightRequests: number,
+    maxQueuedObjects: number,
+    maxOpenStreams: number,
     authInfo: string | undefined,
     moqMapping: MoqMapping,
   ): Promise<Track> {
@@ -795,7 +848,8 @@ export class Moq {
       name,
       trackAlias,
       requestId,
-      maxInFlightRequests,
+      maxQueuedObjects,
+      maxOpenStreams,
       authInfo,
       moqMapping,
     );

--- a/src/sender/moq/moq_sender_internals.ts
+++ b/src/sender/moq/moq_sender_internals.ts
@@ -20,6 +20,7 @@ export interface TrackData {
   name: string;
   authInfo?: string;
   maxInFlightRequests?: number;
+  maxOpenStreams?: number;
   isHipri?: boolean;
   moqMapping?: string;
   newSubgroupEvery?: number;
@@ -174,6 +175,7 @@ export class MoqSender {
       trackData.namespace,
       trackData.name,
       trackData.maxInFlightRequests ?? Number.MAX_SAFE_INTEGER,
+      trackData.maxOpenStreams ?? Number.MAX_SAFE_INTEGER,
       trackData.authInfo,
       trackData.moqMapping as MoqMapping,
     );
@@ -352,10 +354,16 @@ export class MoqSender {
   }
 
   private emitStats(): void {
-    const inFlightReq: Record<string, number> = {};
+    // Two distinct signals: queuedReq = objects waiting in the send queue (the
+    // backpressure cap), openStreamsReq = open QUIC subgroup streams (the meaning
+    // the v14 "inflight" stat had; ~1 for subgroup, 0 for datagram).
+    const queuedReq: Record<string, number> = {};
+    const openStreamsReq: Record<string, number> = {};
     for (const [mediaType, track] of Object.entries(this.tracks)) {
-      inFlightReq[mediaType] = track.getInfo().numInFlight;
+      const info = track.getInfo();
+      queuedReq[mediaType] = info.numQueued;
+      openStreamsReq[mediaType] = info.numOpenStreams;
     }
-    self.postMessage({ type: 'sendstats', clkms: Date.now(), inFlightReq });
+    self.postMessage({ type: 'sendstats', clkms: Date.now(), queuedReq, openStreamsReq });
   }
 }

--- a/tests/moq.test.ts
+++ b/tests/moq.test.ts
@@ -12,14 +12,16 @@ const BASE_PRI = MOQ_PUBLISHER_PRIORITY_BASE_DEFAULT;
 const flush = () => new Promise((r) => setTimeout(r, 0));
 
 // A minimal stand-in for the bits of `Moq` that `Track` touches.
-function fakeMoq(opts: { hangStream?: boolean } = {}) {
+function fakeMoq(opts: { hangStream?: boolean; hangClose?: boolean } = {}) {
   const writes: any[] = [];
   const writer = {
     write: (b: any) => {
       writes.push(b);
       return Promise.resolve();
     },
-    close: () => Promise.resolve(),
+    // hangClose keeps each stream "open" forever (close never settles), so the
+    // open-stream counter accumulates — used to exercise the maxOpenStreams cap.
+    close: () => (opts.hangClose ? new Promise<void>(() => {}) : Promise.resolve()),
     releaseLock: () => {},
     ready: Promise.resolve(),
   };
@@ -37,8 +39,13 @@ function fakeMoq(opts: { hangStream?: boolean } = {}) {
   return { moq, writes };
 }
 
-function makeTrack(moq: any, mapping: MoqMapping, maxInFlight = 1000): Track {
-  return new Track(moq, ['vc'], 'v0', 2, 7, maxInFlight, undefined, mapping);
+function makeTrack(
+  moq: any,
+  mapping: MoqMapping,
+  maxInFlight = 1000,
+  maxOpenStreams = 1000,
+): Track {
+  return new Track(moq, ['vc'], 'v0', 2, 7, maxInFlight, maxOpenStreams, undefined, mapping);
 }
 
 describe('Track sequencing', () => {
@@ -103,6 +110,81 @@ describe('Track queue policy', () => {
     expect(obj.getInfo().status).toBe('sent');
     obj.abort();
     expect(obj.getInfo().status).toBe('sent');
+  });
+});
+
+describe('Track info counters (numQueued / numOpenStreams)', () => {
+  it('subgroup: opens one stream per group, no queue backlog once written', async () => {
+    const { moq } = fakeMoq();
+    const track = makeTrack(moq, MoqMapping.SubgroupPerGroup);
+    track._setForwarding(true);
+
+    track.sendObject(new Uint8Array([1]), { priority: BASE_PRI });
+    await flush();
+    expect(track.getInfo().numQueued).toBe(0);
+    expect(track.getInfo().numOpenStreams).toBe(1);
+  });
+
+  it('datagram: never opens a subgroup stream', async () => {
+    const { moq } = fakeMoq();
+    const track = makeTrack(moq, MoqMapping.ObjectPerDatagram);
+    track._setForwarding(true);
+
+    track.sendObject(new Uint8Array([1]), { priority: BASE_PRI });
+    await flush();
+    expect(track.getInfo().numQueued).toBe(0);
+    expect(track.getInfo().numOpenStreams).toBe(0);
+  });
+
+  it('numQueued reflects objects waiting while stream creation is stalled', async () => {
+    const { moq } = fakeMoq({ hangStream: true });
+    const track = makeTrack(moq, MoqMapping.SubgroupPerGroup);
+    track._setForwarding(true);
+
+    track.sendObject(new Uint8Array([1]), { priority: BASE_PRI }); // drains, stalls opening the stream
+    track.sendObject(new Uint8Array([2])); // waits in the queue
+    await flush();
+    expect(track.getInfo().numQueued).toBe(2);
+    expect(track.getInfo().numOpenStreams).toBe(0);
+  });
+});
+
+describe('Track open-stream cap (maxOpenStreams)', () => {
+  it('drops a new group once too many subgroup streams are still open', async () => {
+    // Stream closes never settle, so each new group leaves its stream "open".
+    const { moq } = fakeMoq({ hangClose: true });
+    const track = makeTrack(moq, MoqMapping.SubgroupPerGroup, 1000, 2); // maxOpenStreams = 2
+    track._setForwarding(true);
+
+    const g0 = track.sendObject(new Uint8Array([1]), { priority: BASE_PRI });
+    await flush();
+    const g1 = track.sendObject(new Uint8Array([2]), { priority: BASE_PRI });
+    await flush();
+    const g2 = track.sendObject(new Uint8Array([3]), { priority: BASE_PRI });
+    await flush();
+
+    expect(g0.getInfo().status).toBe('sent');
+    expect(g1.getInfo().status).toBe('sent');
+    expect(g2.getInfo().status).toBe('dropped'); // cap reached -> new group dropped
+    expect(track.getInfo().numOpenStreams).toBe(2);
+  });
+
+  it('drops the rest of a group whose start was refused, until a new group fits', async () => {
+    const { moq } = fakeMoq({ hangClose: true });
+    const track = makeTrack(moq, MoqMapping.SubgroupPerGroup, 1000, 1); // maxOpenStreams = 1
+    track._setForwarding(true);
+
+    const key = track.sendObject(new Uint8Array([1]), { priority: BASE_PRI }); // opens group 0
+    await flush();
+    // Next keyframe is refused (1 stream already open); its delta is refused too.
+    const refusedKey = track.sendObject(new Uint8Array([2]), { priority: BASE_PRI });
+    const refusedDelta = track.sendObject(new Uint8Array([3]));
+    await flush();
+
+    expect(key.getInfo().status).toBe('sent');
+    expect(refusedKey.getInfo().status).toBe('dropped');
+    expect(refusedDelta.getInfo().status).toBe('dropped');
+    expect(track.getInfo().numOpenStreams).toBe(1);
   });
 });
 


### PR DESCRIPTION
# `fix/open-streams-counter` — Summary

Splits the misleading **in-flight** counter into two distinct metrics, adds an **open-QUIC-stream cap**, and defaults audio to subgroup-per-frame.

- **Counters split:** `numInFlight` → `numQueued` (send-queue depth) + new `numOpenStreams`; internal cap `maxInFlightRequests` → `maxQueuedObjects` (public config key unchanged). `sendstats` now emits `queuedReq` + `openStreamsReq`.
- **New `maxOpenStreams` cap:** drops a whole new group instead of opening unbounded streams; stream close is now fire-and-forget so the drain isn't blocked.
- **Demo:** Advanced section gets *Queue limits* (audio 20 / video 10) and *QUIC stream limits* (audio 60 / video 39) boxes; stats + timeline show queued (solid) vs open streams (dashed).
- **Audio default:** Subgroup per frame (was Object per datagram).
- **Breaking:** `addTrack(...)` and `Track` gain a `maxOpenStreams` param; consumers read `queuedReq`/`openStreamsReq` instead of `inFlightReq`.
- **Verified:** build + lint clean, 82/82 tests pass.