### PR TITLE
Upgrade MoQ transport from draft-16 to draft-18

### DIFF
--- a/src/moq/README.md
+++ b/src/moq/README.md
@@ -2,13 +2,13 @@
 
 `src/moq/moq.ts` provides a small, **media-free** client API for
 [Media over QUIC Transport (MoQT)](https://datatracker.ietf.org/doc/draft-ietf-moq-transport/)
-**draft‑16**, running in the browser over **WebTransport**. It wraps the
+**draft-18**, running in the browser over **WebTransport**. It wraps the
 low-level wire codec in [`moqt.ts`](./moqt.ts) and the varint codec in
 [`varint.ts`](./varint.ts) and exposes three small classes:
 
 | Class | Role | Created by |
 |-------|------|------------|
-| [`Moq`](#moq) | The session: transport, SETUP handshake, control loop | `new Moq()` |
+| [`Moq`](#moq) | The session: transport, SETUP handshake, incoming stream loops | `new Moq()` |
 | [`Track`](#track) | A track you **publish** | `moq.addTrack(...)` |
 | [`Subscription`](#subscription) | A track you **subscribe** to | `moq.subscribe(...)` |
 | [`ObjData`](#objdata) | A handle to one published object | `track.sendObject(...)` |
@@ -96,13 +96,15 @@ stateDiagram-v2
 ```
 
 - **`init()` is synchronous** and returns immediately; it opens the WebTransport
-  connection and the control stream in the background.
-- **`setup()`** awaits that readiness, performs the CLIENT/SERVER_SETUP
-  handshake, and starts the background control loop. The MoQT **version is
-  negotiated by the transport via ALPN / `WT-Available-Protocols`** (draft‑16),
-  so `setup()` carries no version argument.
+  connection and the local unidirectional control stream in the background.
+- **`setup()`** awaits that readiness, exchanges the single `SETUP` message
+  (draft-18 merged CLIENT/SERVER_SETUP into one, sent on each peer's own
+  unidirectional control stream), and starts the incoming stream/datagram loops.
+  The MoQT **version is negotiated by the transport via ALPN /
+  `WT-Available-Protocols`** (draft-18), so `setup()` carries no version argument.
 - `addTrack()` / `subscribe()` also await readiness, so you can call them right
-  after `setup()`.
+  after `setup()`. Each opens its **own bidirectional request stream** (draft-18);
+  the peer's `REQUEST_OK` / `SUBSCRIBE_OK` (or `REQUEST_ERROR`) is read back on it.
 
 ### Publish flow
 
@@ -113,9 +115,9 @@ sequenceDiagram
   participant Relay
   App->>Moq: init(url, { alpnVersion })
   App->>Moq: await setup()
-  App->>Moq: await addTrack(ns, name, maxQueuedObjects, auth, mapping)
-  Moq->>Relay: PUBLISH
-  Relay-->>Moq: PUBLISH_OK (Forward State 0 or 1)
+  App->>Moq: await addTrack(ns, name, maxQueuedObjects, maxOpenStreams, auth, mapping)
+  Moq->>Relay: PUBLISH (on its own bidi request stream)
+  Relay-->>Moq: REQUEST_OK (Forward State 0 or 1)
   Moq-->>App: Track
   loop per encoded frame
     App->>Moq: track.sendObject(bytes, newGroup?, extHeaders?)
@@ -124,8 +126,9 @@ sequenceDiagram
   Relay-->>Moq: REQUEST_UPDATE (Forward State 1/0 as subscribers come/go)
 ```
 
-> **Forward State gating.** A relay typically replies `PUBLISH_OK` with **Forward
-> State 0** ("I have no subscribers yet") and later sends `REQUEST_UPDATE` to flip
+> **Forward State gating.** A relay typically replies `REQUEST_OK` with **Forward
+> State 0** ("I have no subscribers yet") and later sends `REQUEST_UPDATE` (on the
+> track's publish stream) to flip
 > it to 1 when a subscriber appears (and back to 0 when the last one leaves).
 > While Forward State is 0, `track.sendObject()` returns objects with status
 > `dropped` and nothing is sent — so you don't waste uplink when nobody is
@@ -180,9 +183,10 @@ Open the transport. **Synchronous**; connection setup runs in the background.
 ```ts
 setup(keepAliveOpts?: KeepAliveOptions): Promise<void>
 ```
-Await connection readiness, run the SETUP handshake, and start the control loop.
-Throws if called before `init()`. Pass [`KeepAliveOptions`](#keepaliveoptions) to
-enable the idle keep-alive loop. Moves the session to `Running`.
+Await connection readiness, run the SETUP handshake, and start the incoming
+stream/datagram loops. Throws if called before `init()`. Pass
+[`KeepAliveOptions`](#keepaliveoptions) to enable the idle keep-alive loop. Moves
+the session to `Running`.
 
 ```ts
 addTrack(
@@ -194,8 +198,9 @@ addTrack(
   moqMapping: MoqMapping,
 ): Promise<Track>
 ```
-Publish a track: sends `PUBLISH` and resolves with a [`Track`](#track) once the
-peer replies `PUBLISH_OK`. `namespace` is a tuple (array) of name segments;
+Publish a track: opens a bidirectional request stream, sends `PUBLISH` on it, and
+resolves with a [`Track`](#track) once the peer replies `REQUEST_OK`. `namespace`
+is a tuple (array) of name segments;
 `name` is the track name. `maxQueuedObjects` bounds the per-track send queue and
 `maxOpenStreams` bounds the concurrent open subgroup streams — a new group is
 dropped while that many streams are still open (both `<= 0` mean unbounded).
@@ -302,7 +307,7 @@ A track you subscribe to. Identity + the per-object callback.
 
 ```ts
 getInfo(): SubscriptionInfo     // snapshot of identity
-unsubscribe(): Promise<void>    // best-effort UNSUBSCRIBE; idempotent
+unsubscribe(): Promise<void>    // draft-18: close the request stream (no UNSUBSCRIBE msg); idempotent
 ```
 
 ---
@@ -343,7 +348,7 @@ enum MoqState { Idle, Connecting, Running, Closed }
 ```ts
 interface MoqInitOptions {
   serverCertificateHash?: Uint8Array | null; // SHA-256 hash for serverCertificateHashes
-  alpnVersion?: string;                      // e.g. "moqt-16"; defaults to MOQ_ALPN_DRAFT16_VERSION
+  alpnVersion?: string;                      // e.g. "moqt-18"; defaults to MOQ_ALPN_DRAFT18_VERSION
 }
 ```
 `alpnVersion` is offered to WebTransport as `protocols` (the transport-level
@@ -398,7 +403,7 @@ interface ObjInfo { objId: number; groupId: number; status: ObjStatus }
 import { Moq, MoqMapping } from './moq/moq.js';
 
 const moq = new Moq();
-moq.init('https://localhost:4433/moq', { alpnVersion: 'moqt-16' });
+moq.init('https://localhost:4433/moq', { alpnVersion: 'moqt-18' });
 await moq.setup({ everyMs: 5000 }); // optional keep-alive while idle
 
 const video = await moq.addTrack(
@@ -462,7 +467,7 @@ async function readExactly(
 
 ```ts
 const moq = new Moq();
-moq.init(url, { alpnVersion: 'moqt-16' });
+moq.init(url, { alpnVersion: 'moqt-18' });
 await moq.setup();
 
 const track = await moq.addTrack(ns, 'data0', 0, 0, undefined, MoqMapping.ObjectPerDatagram);

--- a/src/moq/moq.ts
+++ b/src/moq/moq.ts
@@ -12,9 +12,11 @@ LICENSE file in the root directory of this source tree.
 //
 //   const moq = new Moq();
 //   moq.init(urlHostPort, { serverCertificateHash, alpnVersion });   // sync, starts connecting
-//   await moq.setup();                                              // CLIENT/SERVER_SETUP
+//   await moq.setup();                                              // SETUP handshake
 //   // The MOQT version is negotiated by the transport via ALPN /
-//   // WT-Available-Protocols (draft-16), so setup() carries no version.
+//   // WT-Available-Protocols (draft-18), so setup() carries no version. draft-18
+//   // uses a pair of unidirectional control streams and runs each request
+//   // (PUBLISH / SUBSCRIBE / ...) on its own bidirectional stream.
 //
 //   // Publish:
 //   const track = await moq.addTrack(ns, name, maxQueuedObjects, maxOpenStreams, auth, mapping);
@@ -33,14 +35,15 @@ import {
   moqCreate,
   moqClose,
   moqCreateControlStream,
-  moqSendClientSetup,
+  moqSendSetup,
   moqParseMsg,
+  moqParseControlMessageWithType,
+  moqReadVarintType,
+  moqParseObjectHeaderWithType,
   moqSendPublish,
   moqSendPublishDone,
   moqSendSubscribe,
-  moqSendUnSubscribe,
-  moqSendSubscribeOk,
-  moqSendRequestError,
+  moqSendRequestUpdate,
   moqSendSubgroupHeader,
   moqSendObjectSubgroupToWriter,
   moqSendObjectEndOfGroupToWriter,
@@ -50,29 +53,23 @@ import {
   isMoqObjectStreamHeaderType,
   isMoqObjectDatagramType,
   moqDecodeDatagramType,
-  getAuthInfofromParameters,
   getTrackFullName,
-  MOQ_MESSAGE_SERVER_SETUP,
-  MOQ_MESSAGE_PUBLISH_OK,
+  MOQ_MESSAGE_SETUP,
   MOQ_MESSAGE_PUBLISH_DONE,
-  MOQ_MESSAGE_MAX_REQUEST_ID,
-  MOQ_MESSAGE_SUBSCRIBE,
   MOQ_MESSAGE_SUBSCRIBE_OK,
   MOQ_MESSAGE_REQUEST_OK,
-  MOQ_MESSAGE_REQUEST_ERROR,
   MOQ_MESSAGE_REQUEST_UPDATE,
-  MOQ_MESSAGE_UNSUBSCRIBE,
+  MOQ_STREAM_TYPE_PADDING,
   MOQ_PARAMETER_FORWARD,
   MOQ_OBJ_STATUS_END_OF_GROUP,
   MOQ_OBJ_STATUS_END_OF_TRACK_AND_GROUP,
   MOQ_PUBLISHER_PRIORITY_BASE_DEFAULT,
-  MOQ_SUBSCRIPTION_ERROR_INTERNAL,
   MOQ_STATUS_TRACK_ENDED,
   MOQ_FORWARD_TRUE,
   type MoqtState,
   type KvPair,
   type ObjectHeader,
-  MOQ_ALPN_DRAFT16_VERSION,
+  MOQ_ALPN_DRAFT18_VERSION,
 } from './moqt.js';
 
 const LOG_PREFIX = '[MOQ]';
@@ -126,10 +123,10 @@ export interface TrackInfo {
 export interface MoqInitOptions {
   // SHA-256 hash of the server certificate, for WebTransport `serverCertificateHashes`.
   serverCertificateHash?: Uint8Array | null;
-  // MOQT ALPN token (e.g. "moqt-16"). draft-16 negotiates the version via the
+  // MOQT ALPN token (e.g. "moqt-18"). draft-18 negotiates the version via the
   // transport (ALPN over native QUIC, WT-Available-Protocols over WebTransport),
   // so this is offered to WebTransport as `protocols` rather than sent in SETUP.
-  // Optional; defaults to MOQ_ALPN_DRAFT16_VERSION when omitted.
+  // Optional; defaults to MOQ_ALPN_DRAFT18_VERSION when omitted.
   alpnVersion?: string;
 }
 
@@ -242,10 +239,14 @@ export class Track {
   subscribers: Subscriber[] = [];
 
   private moq: Moq;
+  // draft-18: each request runs on its own bidirectional stream. PUBLISH was sent
+  // on this stream; REQUEST_OK / REQUEST_UPDATE (Forward State) and the final
+  // PUBLISH_DONE all flow back on it.
+  private publishStream: WebTransportBidirectionalStream;
   private queue: ObjData[] = [];
   private draining = false;
   private closed = false;
-  // Forward State for this subscription (draft-16). The relay toggles it via
+  // Forward State for this subscription (draft-18). The relay toggles it via
   // REQUEST_UPDATE; objects are only sent while it is true. Starts false: the
   // relay's PUBLISH_OK parks new tracks at Forward State 0 until a subscriber
   // appears.
@@ -282,6 +283,7 @@ export class Track {
     maxOpenStreams: number,
     authInfo: string | undefined,
     moqMapping: MoqMapping,
+    publishStream: WebTransportBidirectionalStream,
   ) {
     this.moq = moq;
     this.namespace = namespace;
@@ -292,6 +294,7 @@ export class Track {
     this.maxOpenStreams = maxOpenStreams > 0 ? maxOpenStreams : Number.MAX_SAFE_INTEGER;
     this.authInfo = authInfo;
     this.moqMapping = moqMapping;
+    this.publishStream = publishStream;
   }
 
   /**
@@ -318,7 +321,7 @@ export class Track {
 
     let newGroup = newGroupOptions !== undefined;
 
-    // Forward-state gating (draft-16 §5.1): the publisher does not send Objects
+    // Forward-state gating (draft-18 §5.1): the publisher does not send Objects
     // while Forward State is 0. The relay toggles this via REQUEST_UPDATE (see
     // Moq.onRequestUpdate -> Track._setForwarding).
     if (!this.forwarding) {
@@ -429,20 +432,55 @@ export class Track {
     this.openStreams.clear();
     this.openStreamCount = 0;
 
+    // draft-18: PUBLISH_DONE goes back on this request's own bidi stream (no
+    // Request ID field — the stream identifies the request); then FIN it.
     try {
       await moqSendPublishDone(
-        this.moq._controlWriter(),
-        this.publisherRequestId,
+        this.publishStream.writable,
         MOQ_STATUS_TRACK_ENDED,
         this.subscribers.length,
         'Subscription Ended, the stream has finished',
       );
+      await this.publishStream.writable.close();
     } catch {
       // Best-effort on teardown.
     }
   }
 
   // ---- internal (called by Moq / ObjData) --------------------------------
+
+  // The writable half of the PUBLISH request stream (used for keep-alive).
+  _publishWritable(): WritableStream<Uint8Array> {
+    return this.publishStream.writable;
+  }
+
+  // Read REQUEST_UPDATE (Forward State toggles) and other late control messages
+  // that the peer sends on the publish stream after the initial REQUEST_OK. In
+  // draft-18 the message arrives on this track's own stream, so it is inherently
+  // scoped to this track (no Existing Request ID lookup needed).
+  async _runResponseLoop(): Promise<void> {
+    try {
+      for (;;) {
+        const msg = await moqParseMsg(this.publishStream.readable);
+        if (msg.type === MOQ_MESSAGE_REQUEST_UPDATE) {
+          const forward = forwardFromParameters(msg.data?.parameters ?? []);
+          if (forward === MOQ_FORWARD_TRUE) {
+            this._addSubscriber(this.publisherRequestId, MOQ_FORWARD_TRUE, msg.data.parameters);
+            this._setForwarding(true);
+          } else {
+            this._removeSubscribersByRequestId(this.publisherRequestId);
+            this._setForwarding(false);
+          }
+        } else if (msg.type === MOQ_MESSAGE_PUBLISH_DONE) {
+          console.log(`${LOG_PREFIX} publish stream PUBLISH_DONE ${JSON.stringify(msg.data)}`);
+          break;
+        }
+        // Ignore other late control messages.
+      }
+    } catch {
+      // Stream closed/reset: the peer is done with this publication.
+    }
+  }
 
   // True when the subscription is being forwarded (Forward State 1).
   isForwarding(): boolean {
@@ -656,6 +694,10 @@ export class Subscription {
 
   private moq: Moq;
   private onObject: ObjectCallback;
+  // draft-18: SUBSCRIBE ran on this bidi stream; SUBSCRIBE_OK / PUBLISH_DONE and
+  // any REQUEST_UPDATE flow back on it. Objects still arrive on separate uni
+  // subgroup streams / datagrams, routed by track alias.
+  private subscribeStream: WebTransportBidirectionalStream;
   private closed = false;
 
   constructor(
@@ -666,6 +708,7 @@ export class Subscription {
     trackAlias: number,
     authInfo: string | undefined,
     onObject: ObjectCallback,
+    subscribeStream: WebTransportBidirectionalStream,
   ) {
     this.moq = moq;
     this.namespace = namespace;
@@ -674,6 +717,7 @@ export class Subscription {
     this.trackAlias = trackAlias;
     this.authInfo = authInfo;
     this.onObject = onObject;
+    this.subscribeStream = subscribeStream;
   }
 
   /** Snapshot of the subscription's identity. */
@@ -686,20 +730,50 @@ export class Subscription {
     };
   }
 
-  /** Stop the subscription (best-effort UNSUBSCRIBE). */
+  /**
+   * Stop the subscription. draft-18 removed the UNSUBSCRIBE message: cancelling
+   * the request stream's readable (STOP_SENDING) and closing its writable (FIN)
+   * signals the publisher to stop sending objects for this subscription.
+   */
   async unsubscribe(): Promise<void> {
     if (this.closed) {
       return;
     }
     this.closed = true;
     try {
-      await moqSendUnSubscribe(this.moq._controlWriter(), this.subscribeRequestId);
+      await this.subscribeStream.readable.cancel('unsubscribe'); // STOP_SENDING
+    } catch {
+      // Best-effort on teardown.
+    }
+    try {
+      await this.subscribeStream.writable.close();
     } catch {
       // Best-effort on teardown.
     }
   }
 
   // ---- internal (called by Moq receive loops) ----------------------------
+
+  // The writable half of the SUBSCRIBE request stream (used for keep-alive).
+  _requestWritable(): WritableStream<Uint8Array> {
+    return this.subscribeStream.writable;
+  }
+
+  // Read PUBLISH_DONE / late control messages that arrive on the subscribe
+  // stream after SUBSCRIBE_OK. A stream close/reset ends the subscription.
+  async _runResponseLoop(): Promise<void> {
+    try {
+      for (;;) {
+        const msg = await moqParseMsg(this.subscribeStream.readable);
+        if (msg.type === MOQ_MESSAGE_PUBLISH_DONE) {
+          console.log(`${LOG_PREFIX} subscribe stream PUBLISH_DONE ${JSON.stringify(msg.data)}`);
+          break;
+        }
+      }
+    } catch {
+      // Stream closed/reset.
+    }
+  }
 
   // Hand one received object payload to the callback; returns its EOF result.
   async _deliver(
@@ -742,21 +816,17 @@ export class Moq {
   private keepAliveInterval: ReturnType<typeof setInterval> | null = null;
   private lastObjectSentMs = 0;
 
-  // Pending addTrack PUBLISH requests, keyed by request id.
-  private pendingPublish = new Map<
-    number,
-    { resolve: (data: any) => void; reject: (err: any) => void }
-  >();
-
   // Subscriber state.
   private subscriptions: Subscription[] = [];
   private subscriptionsByAlias = new Map<number, Subscription>();
-  private receiveLoopsStarted = false;
-  // Pending subscribe SUBSCRIBE requests, keyed by request id.
-  private pendingSubscribe = new Map<
-    number,
-    { resolve: (data: any) => void; reject: (err: any) => void }
-  >();
+  private incomingLoopsStarted = false;
+
+  // Resolves once the peer's SETUP has been received on its incoming control
+  // (unidirectional) stream. draft-18 handshakes over a pair of uni streams
+  // rather than a single bidi control stream, so we cannot simply read the reply
+  // back on the stream we wrote to.
+  private peerSetupReceived: Promise<void> | null = null;
+  private resolvePeerSetup: (() => void) | null = null;
 
   /**
    * Open the transport (sync). Connection + control stream creation happen in
@@ -775,7 +845,7 @@ export class Moq {
     // Offer the MOQT version for transport-level negotiation. The browser maps
     // `protocols` to the WT-Available-Protocols header; engines that do not yet
     // support it ignore the option (no version is then offered).
-    wtOptions.protocols = [options.alpnVersion ?? MOQ_ALPN_DRAFT16_VERSION];
+    wtOptions.protocols = [options.alpnVersion ?? MOQ_ALPN_DRAFT18_VERSION];
 
     console.info(`${LOG_PREFIX} Opening MOQT to ${url}, options: ${JSON.stringify(wtOptions)}`);
 
@@ -791,33 +861,38 @@ export class Moq {
     })();
   }
 
-  /** Perform the MoQ SETUP handshake and start the control loop. */
+  /** Perform the MoQ SETUP handshake and start the incoming receive loops. */
   async setup(keepAliveOpts?: KeepAliveOptions): Promise<void> {
     if (this._state === MoqState.Idle) {
       throw new Error('setup() called before init()');
     }
     await this.connecting;
 
-    await moqSendClientSetup(this.controlWriter());
-    const msg = await moqParseMsg(this.controlReader());
-    if (msg.type !== MOQ_MESSAGE_SERVER_SETUP) {
-      throw new Error(`Expected MOQ_MESSAGE_SERVER_SETUP, received ${msg.type}`);
-    }
+    this.peerSetupReceived = new Promise<void>((resolve) => {
+      this.resolvePeerSetup = resolve;
+    });
+
+    // The peer's SETUP arrives on its own incoming unidirectional stream, so the
+    // incoming loops must be running before we can complete the handshake.
+    this.ensureIncomingLoops();
+
+    // Send our SETUP on the local unidirectional control stream, then wait for
+    // the peer's SETUP (draft-18 §7).
+    await moqSendSetup(this.controlWriter());
+    await this.peerSetupReceived;
 
     this._state = MoqState.Running;
-    // Control loop runs in the background until close().
-    this.runControlLoop().catch((err) => {
-      if (this._state === MoqState.Running) {
-        console.error(`${LOG_PREFIX} Control loop error: ${err}`);
-      }
-    });
 
     if (keepAliveOpts !== undefined) {
       this.startKeepAlive(keepAliveOpts);
     }
   }
 
-  /** Publish a track (sends PUBLISH, resolves on PUBLISH_OK). */
+  /**
+   * Publish a track. draft-18: open a dedicated bidirectional stream, send
+   * PUBLISH on it, and await the peer's REQUEST_OK (or REQUEST_ERROR) read back
+   * on that same stream.
+   */
   async addTrack(
     namespace: string[],
     name: string,
@@ -836,11 +911,22 @@ export class Moq {
     const trackAlias = this.allocateTrackAlias();
     const requestId = this.allocateClientReqId();
 
-    const published = new Promise<any>((resolve, reject) => {
-      this.pendingPublish.set(requestId, { resolve, reject });
-    });
-    await moqSendPublish(this.controlWriter(), requestId, namespace, name, trackAlias, authInfo, 1);
-    const resp = await published;
+    const pubStream: WebTransportBidirectionalStream =
+      await this.moqt.wt.createBidirectionalStream();
+    await moqSendPublish(
+      pubStream.writable,
+      requestId,
+      namespace,
+      name,
+      trackAlias,
+      authInfo,
+      MOQ_FORWARD_TRUE,
+    );
+
+    const resp = await moqParseMsg(pubStream.readable);
+    if (resp.type !== MOQ_MESSAGE_REQUEST_OK) {
+      throw new Error(`PUBLISH rejected (${resp.type}): ${JSON.stringify(resp.data)}`);
+    }
 
     const track = new Track(
       this,
@@ -852,22 +938,27 @@ export class Moq {
       maxOpenStreams,
       authInfo,
       moqMapping,
+      pubStream,
     );
-    // FORWARD defaults to 1 when the parameter is absent (draft-16 §9.2.2.8).
-    // Relays typically PUBLISH_OK with Forward State 0 until a subscriber exists.
-    const forwarding = forwardFromParameters(resp?.parameters ?? []) !== 0;
+    // FORWARD defaults to 1 when the parameter is absent (draft-18 §9.2.2.8).
+    // Relays typically REQUEST_OK with Forward State 0 until a subscriber exists,
+    // then flip it via REQUEST_UPDATE on the publish stream (Track._runResponseLoop).
+    const forwarding = forwardFromParameters(resp.data?.parameters ?? []) !== 0;
     if (forwarding) {
-      track._addSubscriber(requestId, MOQ_FORWARD_TRUE, resp?.parameters ?? []);
+      track._addSubscriber(requestId, MOQ_FORWARD_TRUE, resp.data?.parameters ?? []);
     }
     track._setForwarding(forwarding);
     this.tracks.push(track);
+    void track._runResponseLoop();
     return track;
   }
 
   /**
-   * Subscribe to a track (sends SUBSCRIBE, resolves on SUBSCRIBE_OK). Objects
-   * received for the track are routed to `onObject` by the negotiated track
-   * alias. A SUBSCRIBE_ERROR is retried after `SLEEP_SUBSCRIBE_ERROR_MS`.
+   * Subscribe to a track. draft-18: open a dedicated bidirectional stream, send
+   * SUBSCRIBE on it, and await SUBSCRIBE_OK read back on the same stream. Objects
+   * arrive on separate unidirectional subgroup streams / datagrams, routed to
+   * `onObject` by the negotiated track alias. A rejection is retried after
+   * `SLEEP_SUBSCRIBE_ERROR_MS` with a fresh request stream.
    */
   async subscribe(
     namespace: string[],
@@ -884,39 +975,49 @@ export class Moq {
 
     // Make sure the incoming stream / datagram receive loops are running before
     // any objects can arrive.
-    this.ensureReceiveLoops();
+    this.ensureIncomingLoops();
 
-    // Retry on SUBSCRIBE_ERROR with a fresh request id, mirroring the relay
+    // Retry on rejection with a fresh request id + stream, mirroring the relay
     // race handling the legacy downloader had.
     for (;;) {
       const requestId = this.allocateClientReqId();
-      const answered = new Promise<any>((resolve, reject) => {
-        this.pendingSubscribe.set(requestId, { resolve, reject });
-      });
-      await moqSendSubscribe(this.controlWriter(), requestId, namespace, name, authInfo);
-      try {
-        const resp = await answered;
+      const subStream: WebTransportBidirectionalStream =
+        await this.moqt.wt.createBidirectionalStream();
+      await moqSendSubscribe(subStream.writable, requestId, namespace, name, authInfo);
+
+      const resp = await moqParseMsg(subStream.readable);
+      if (resp.type === MOQ_MESSAGE_SUBSCRIBE_OK) {
+        const trackAlias = resp.data.trackAlias;
         const sub = new Subscription(
           this,
           namespace,
           name,
           requestId,
-          resp.trackAlias,
+          trackAlias,
           authInfo,
           onObject,
+          subStream,
         );
         this.subscriptions.push(sub);
-        this.subscriptionsByAlias.set(resp.trackAlias, sub);
+        this.subscriptionsByAlias.set(trackAlias, sub);
+        void sub._runResponseLoop();
         console.log(
-          `${LOG_PREFIX} SUBSCRIBE_OK for ${getTrackFullName(namespace as any, name)} (alias ${resp.trackAlias})`,
+          `${LOG_PREFIX} SUBSCRIBE_OK for ${getTrackFullName(namespace as any, name)} (alias ${trackAlias})`,
         );
         return sub;
-      } catch (err) {
-        console.warn(
-          `${LOG_PREFIX} SUBSCRIBE_ERROR for ${getTrackFullName(namespace as any, name)}: ${err}. Retrying in ${SLEEP_SUBSCRIBE_ERROR_MS}ms`,
-        );
-        await new Promise((r) => setTimeout(r, SLEEP_SUBSCRIBE_ERROR_MS));
       }
+
+      // REQUEST_ERROR or unexpected: close the stream and retry.
+      console.warn(
+        `${LOG_PREFIX} SUBSCRIBE failed for ${getTrackFullName(namespace as any, name)} (${resp.type}): ${JSON.stringify(resp.data)}. Retrying in ${SLEEP_SUBSCRIBE_ERROR_MS}ms`,
+      );
+      try {
+        await subStream.writable.close();
+        await subStream.readable.cancel('retry');
+      } catch {
+        // ignore
+      }
+      await new Promise((r) => setTimeout(r, SLEEP_SUBSCRIBE_ERROR_MS));
     }
   }
 
@@ -928,20 +1029,16 @@ export class Moq {
     this._state = MoqState.Closed;
     this.stopKeepAlive();
 
-    // Tear down asynchronously: tracks must finish closing (they send
-    // PUBLISH_DONE on the control stream, which locks the control writer)
-    // BEFORE moqClose() closes that stream, otherwise the writer is still
-    // locked and close() throws "Cannot close a locked stream".
+    // Tear down asynchronously. draft-18: each track/subscription closes its own
+    // request stream (PUBLISH_DONE + FIN / STOP_SENDING), independent of the
+    // unidirectional control stream, before moqClose() tears down the transport.
     const tracks = this.tracks;
     this.tracks = [];
     const subscriptions = this.subscriptions;
     this.subscriptions = [];
     this.subscriptionsByAlias.clear();
     void (async () => {
-      // Unsubscribe sequentially so we never hold two control-writer locks.
-      for (const sub of subscriptions) {
-        await sub.unsubscribe();
-      }
+      await Promise.allSettled(subscriptions.map((sub) => sub.unsubscribe()));
       await Promise.allSettled(tracks.map((track) => track.close()));
       await moqClose(this.moqt);
     })();
@@ -970,7 +1067,10 @@ export class Moq {
     this.keepAliveOpts = null;
   }
 
-  // Send a keep-alive PUBLISH only when the session has been idle for `everyMs`.
+  // Send a keep-alive only when the session has been idle for `everyMs`. draft-18
+  // has no keep-alive PUBLISH on the control stream; instead we send a no-op
+  // REQUEST_UPDATE on an already-open request stream (a published track's stream,
+  // or failing that a subscription's). No-op when there is nothing open.
   private async maybeSendKeepAlive(): Promise<void> {
     const opts = this.keepAliveOpts;
     if (opts === null || this._state !== MoqState.Running) {
@@ -979,15 +1079,20 @@ export class Moq {
     if (Date.now() - this.lastObjectSentMs <= opts.everyMs) {
       return;
     }
-    await moqSendPublish(
-      this.controlWriter(),
-      this.allocateClientReqId(),
-      [opts.namespace],
-      opts.name,
-      KEEPALIVE_TRACK_ALIAS,
-      undefined,
-    );
-    console.log(`${LOG_PREFIX} Sent keep alive (publish)`);
+    const track = this.tracks[0];
+    const sub = this.subscriptions[0];
+    try {
+      if (track !== undefined) {
+        await moqSendRequestUpdate(track._publishWritable(), track.publisherRequestId, []);
+      } else if (sub !== undefined) {
+        await moqSendRequestUpdate(sub._requestWritable(), sub.subscribeRequestId, []);
+      } else {
+        return;
+      }
+      console.log(`${LOG_PREFIX} Sent keep alive (request update)`);
+    } catch (err) {
+      console.warn(`${LOG_PREFIX} keep alive failed: ${err}`);
+    }
   }
 
   // ---- internal accessors used by Track ----------------------------------
@@ -995,216 +1100,106 @@ export class Moq {
   _wt(): any {
     return this.moqt.wt;
   }
-  _controlWriter(): WritableStream<Uint8Array> {
-    return this.controlWriter();
-  }
   _markObjectSent(): void {
     this.lastObjectSentMs = Date.now();
   }
 
-  // ---- control loop ------------------------------------------------------
+  // ---- incoming stream / datagram loops ----------------------------------
 
-  private async runControlLoop(): Promise<void> {
-    while (this._state === MoqState.Running) {
-      const msg = await moqParseMsg(this.controlReader());
-      switch (msg.type) {
-        case MOQ_MESSAGE_PUBLISH_OK:
-          console.log(`${LOG_PREFIX} received PUBLISH_OK ${JSON.stringify(msg.data)}`);
-          this.resolvePublish(msg.data, true);
-          break;
-        case MOQ_MESSAGE_SUBSCRIBE_OK:
-          console.log(`${LOG_PREFIX} received SUBSCRIBE_OK ${JSON.stringify(msg.data)}`);
-          this.resolveSubscribe(msg.data, true);
-          break;
-        case MOQ_MESSAGE_REQUEST_ERROR:
-          // draft-16 unified error; route by Request ID to whichever request is pending.
-          console.log(`${LOG_PREFIX} received REQUEST_ERROR ${JSON.stringify(msg.data)}`);
-          this.rejectByRequestId(msg.data);
-          break;
-        case MOQ_MESSAGE_REQUEST_OK:
-          // Response to REQUEST_UPDATE/TRACK_STATUS/etc. Informational here.
-          console.log(`${LOG_PREFIX} received REQUEST_OK ${JSON.stringify(msg.data)}`);
-          break;
-        case MOQ_MESSAGE_PUBLISH_DONE:
-          console.log(`${LOG_PREFIX} received PUBLISH_DONE ${JSON.stringify(msg.data)}`);
-          break;
-        case MOQ_MESSAGE_SUBSCRIBE:
-          console.log(`${LOG_PREFIX} received MOQ_MESSAGE_SUBSCRIBE ${JSON.stringify(msg.data)}`);
-          await this.onSubscribe(msg.data);
-          break;
-        case MOQ_MESSAGE_REQUEST_UPDATE:
-          console.log(
-            `${LOG_PREFIX} received MOQ_MESSAGE_REQUEST_UPDATE ${JSON.stringify(msg.data)}`,
-          );
-          this.onRequestUpdate(msg.data);
-          break;
-        case MOQ_MESSAGE_UNSUBSCRIBE:
-          console.log(`${LOG_PREFIX} received MOQ_MESSAGE_UNSUBSCRIBE ${JSON.stringify(msg.data)}`);
-          this.onUnsubscribe(msg.data);
-          break;
-        case MOQ_MESSAGE_MAX_REQUEST_ID:
-          console.log(
-            `${LOG_PREFIX} received MOQ_MESSAGE_MAX_REQUEST_ID ${JSON.stringify(msg.data)}`,
-          );
-          break; // informational
-        default:
-          console.warn(`${LOG_PREFIX} Unexpected control message type ${msg.type}, ignoring`);
-      }
-    }
-  }
-
-  // Resolve a pending addTrack on PUBLISH_OK. An unknown request id is treated
-  // as a keep-alive answer and ignored.
-  private resolvePublish(data: any, ok: boolean): void {
-    const pending = this.pendingPublish.get(data?.reqId);
-    if (pending === undefined) {
+  // Start the incoming unidirectional-stream and datagram loops once. They run
+  // in the background until close(); errors after close are expected. Unlike
+  // draft-18 there is no single control-message loop: request responses are read
+  // on their own bidi streams (Track/Subscription._runResponseLoop), and the peer
+  // SETUP + object subgroups arrive here on incoming unidirectional streams.
+  private ensureIncomingLoops(): void {
+    if (this.incomingLoopsStarted) {
       return;
     }
-    this.pendingPublish.delete(data.reqId);
-    if (ok) {
-      pending.resolve(data);
-    } else {
-      pending.reject(new Error(`PUBLISH rejected: ${JSON.stringify(data)}`));
-    }
-  }
-
-  // Resolve a pending subscribe on SUBSCRIBE_OK. An unknown request id is
-  // ignored (e.g. a late answer after we already retried).
-  private resolveSubscribe(data: any, ok: boolean): void {
-    const pending = this.pendingSubscribe.get(data?.requestId);
-    if (pending === undefined) {
-      return;
-    }
-    this.pendingSubscribe.delete(data.requestId);
-    if (ok) {
-      pending.resolve(data);
-    } else {
-      pending.reject(new Error(`SUBSCRIBE rejected: ${JSON.stringify(data)}`));
-    }
-  }
-
-  // draft-16 REQUEST_ERROR is unified; route it by Request ID to whichever
-  // pending publish or subscribe it answers.
-  private rejectByRequestId(data: any): void {
-    const id = data?.requestId;
-    const err = new Error(`REQUEST_ERROR: ${JSON.stringify(data)}`);
-    const pubPending = this.pendingPublish.get(id);
-    if (pubPending !== undefined) {
-      this.pendingPublish.delete(id);
-      pubPending.reject(err);
-      return;
-    }
-    const subPending = this.pendingSubscribe.get(id);
-    if (subPending !== undefined) {
-      this.pendingSubscribe.delete(id);
-      subPending.reject(err);
-    }
-  }
-
-  private async onSubscribe(subscribe: any): Promise<void> {
-    const fullTrackName = getTrackFullName(subscribe.namespace, subscribe.trackName);
-    const track = this.trackByFullName(fullTrackName);
-    if (track == null) {
-      await moqSendRequestError(
-        this.controlWriter(),
-        subscribe.requestId,
-        MOQ_SUBSCRIPTION_ERROR_INTERNAL,
-        `Unknown track ${fullTrackName}`,
-      );
-      return;
-    }
-    if (!authMatches(track.authInfo, subscribe.parameters)) {
-      await moqSendRequestError(
-        this.controlWriter(),
-        subscribe.requestId,
-        MOQ_SUBSCRIPTION_ERROR_INTERNAL,
-        'Invalid subscribe authInfo',
-      );
-      return;
-    }
-
-    track._addSubscriber(subscribe.requestId, MOQ_FORWARD_TRUE, subscribe.parameters);
-    track._setForwarding(true);
-    const last = track._lastSent();
-    await moqSendSubscribeOk(
-      this.controlWriter(),
-      subscribe.requestId,
-      track.trackAlias,
-      last.group,
-      last.obj,
-    );
-  }
-
-  // draft-16 REQUEST_UPDATE references an Existing Request ID; Forward State is
-  // carried as the FORWARD parameter.
-  private onRequestUpdate(update: any): void {
-    if (!('existingRequestId' in update)) {
-      console.warn(`${LOG_PREFIX} Invalid REQUEST_UPDATE, ignoring`);
-      return;
-    }
-    const track = this.trackByPublisherRequestId(update.existingRequestId);
-    if (track == null || !authMatches(track.authInfo, update.parameters)) {
-      return;
-    }
-    const forward = forwardFromParameters(update.parameters);
-    if (forward === MOQ_FORWARD_TRUE) {
-      track._addSubscriber(update.existingRequestId, MOQ_FORWARD_TRUE, update.parameters);
-      track._setForwarding(true);
-    } else if (forward === 0) {
-      track._removeSubscribersByRequestId(update.existingRequestId);
-      track._setForwarding(false);
-    }
-  }
-
-  private onUnsubscribe(unsubscribe: any): void {
-    if (!('requestId' in unsubscribe)) {
-      return;
-    }
-    for (const track of this.tracks) {
-      const removed = track._removeSubscribersByRequestId(unsubscribe.requestId);
-      if (removed.length > 0 && track.subscribers.length === 0) {
-        track._setForwarding(false);
-      }
-    }
-  }
-
-  // ---- receive loops (subscriber) ----------------------------------------
-
-  // Start the incoming unidirectional-stream and datagram receive loops once.
-  // They run in the background until close(); errors after close are expected.
-  private ensureReceiveLoops(): void {
-    if (this.receiveLoopsStarted) {
-      return;
-    }
-    this.receiveLoopsStarted = true;
-    this.runStreamReceiveLoop().catch((err) => {
-      if (this._state === MoqState.Running) {
-        console.error(`${LOG_PREFIX} Stream receive loop error: ${err}`);
+    this.incomingLoopsStarted = true;
+    this.runIncomingUniLoop().catch((err) => {
+      if (this._state !== MoqState.Closed) {
+        console.error(`${LOG_PREFIX} Incoming stream loop error: ${err}`);
       }
     });
     this.runDatagramReceiveLoop().catch((err) => {
-      if (this._state === MoqState.Running) {
+      if (this._state !== MoqState.Closed) {
         console.error(`${LOG_PREFIX} Datagram receive loop error: ${err}`);
       }
     });
   }
 
-  // Accept incoming unidirectional QUIC streams (one subgroup per stream).
-  private async runStreamReceiveLoop(): Promise<void> {
+  // Accept incoming unidirectional QUIC streams and demux by their leading
+  // stream type: the peer control stream (begins with SETUP), an object subgroup
+  // header, or padding.
+  private async runIncomingUniLoop(): Promise<void> {
     const reader = this._wt().incomingUnidirectionalStreams.getReader();
-    while (this._state === MoqState.Running) {
+    while (this._state !== MoqState.Closed) {
       const { done, value } = await reader.read();
       if (done) {
         break;
       }
-      const header = await moqParseObjectHeader(value);
-      if (!isMoqObjectStreamHeaderType(header.type)) {
-        console.warn(`${LOG_PREFIX} Unsupported incoming stream type ${header.type}`);
-        continue;
+      // No await on purpose: handle each incoming stream concurrently.
+      void this.handleIncomingUniStream(value as ReadableStream<Uint8Array>);
+    }
+  }
+
+  private async handleIncomingUniStream(stream: ReadableStream<Uint8Array>): Promise<void> {
+    let type: number;
+    try {
+      type = await moqReadVarintType(stream);
+    } catch {
+      return; // empty / garbage stream
+    }
+
+    if (type === MOQ_MESSAGE_SETUP) {
+      await this.handlePeerControlStream(stream);
+      return;
+    }
+    if (isMoqObjectStreamHeaderType(type)) {
+      try {
+        const header = await moqParseObjectHeaderWithType(stream, type);
+        await this.receiveSubgroupStream(stream, header);
+      } catch (err) {
+        if (this._state !== MoqState.Closed) {
+          console.warn(`${LOG_PREFIX} subgroup stream error: ${err}`);
+        }
       }
-      // No await on purpose: drain this subgroup stream concurrently with the
-      // next incoming stream.
-      void this.receiveSubgroupStream(value, header);
+      return;
+    }
+    if (type === MOQ_STREAM_TYPE_PADDING) {
+      // Discard padding to release flow control.
+      try {
+        await stream.cancel('padding');
+      } catch {
+        // ignore
+      }
+      return;
+    }
+    console.warn(`${LOG_PREFIX} Unsupported incoming stream type ${type}`);
+  }
+
+  // The peer's control stream begins with SETUP (type already read); consume the
+  // SETUP body to complete the handshake, then drain subsequent control messages
+  // (e.g. GOAWAY) until the stream closes.
+  private async handlePeerControlStream(stream: ReadableStream<Uint8Array>): Promise<void> {
+    this.moqt.controlReader = stream;
+    try {
+      await moqParseControlMessageWithType(stream, MOQ_MESSAGE_SETUP);
+    } catch (err) {
+      console.error(`${LOG_PREFIX} Failed to parse peer SETUP: ${err}`);
+      return;
+    }
+    if (this.resolvePeerSetup !== null) {
+      this.resolvePeerSetup();
+      this.resolvePeerSetup = null;
+    }
+    try {
+      while (this._state !== MoqState.Closed) {
+        const msg = await moqParseMsg(stream);
+        console.log(`${LOG_PREFIX} control message ${msg.type}`);
+      }
+    } catch {
+      // Control stream closed.
     }
   }
 
@@ -1221,7 +1216,7 @@ export class Moq {
     }
     let isEOF = false;
     let numObjRead = 0;
-    while (this._state === MoqState.Running && !isEOF) {
+    while (this._state !== MoqState.Closed && !isEOF) {
       try {
         const objHeader = await moqParseObjectFromSubgroupHeader(readerStream, header.type);
         isEOF = isEndOfGroupStatus(objHeader.status);
@@ -1252,7 +1247,7 @@ export class Moq {
   // Accept incoming datagrams (one object per datagram).
   private async runDatagramReceiveLoop(): Promise<void> {
     const reader = this._wt().datagrams.readable.getReader();
-    while (this._state === MoqState.Running) {
+    while (this._state !== MoqState.Closed) {
       const { done, value } = await reader.read();
       if (done) {
         break;
@@ -1285,19 +1280,6 @@ export class Moq {
   private controlWriter(): WritableStream<Uint8Array> {
     return this.moqt.controlWriter as WritableStream<Uint8Array>;
   }
-  private controlReader(): ReadableStream<Uint8Array> {
-    return this.moqt.controlReader as ReadableStream<Uint8Array>;
-  }
-
-  private trackByFullName(fullTrackName: string): Track | null {
-    return (
-      this.tracks.find((t) => getTrackFullName(t.namespace as any, t.name) === fullTrackName) ??
-      null
-    );
-  }
-  private trackByPublisherRequestId(reqId: number): Track | null {
-    return this.tracks.find((t) => t.publisherRequestId === reqId) ?? null;
-  }
 
   private allocateClientReqId(): number {
     this.nextClientReqId =
@@ -1314,15 +1296,7 @@ function isEndOfGroupStatus(status: number | undefined): boolean {
   return status === MOQ_OBJ_STATUS_END_OF_GROUP || status === MOQ_OBJ_STATUS_END_OF_TRACK_AND_GROUP;
 }
 
-// Auth passes when the track has no authInfo, or the parameters carry a match.
-function authMatches(trackAuth: string | undefined, parameters: KvPair[]): boolean {
-  if (trackAuth == undefined || trackAuth === '') {
-    return true;
-  }
-  return trackAuth === getAuthInfofromParameters(parameters);
-}
-
-// Read the FORWARD parameter (draft-16 §9.2.2.8); returns 1 when absent.
+// Read the FORWARD parameter (draft-18 §9.2.2.8); returns 1 when absent.
 function forwardFromParameters(parameters: KvPair[]): number {
   const fwd = parameters.find((p) => p.name === MOQ_PARAMETER_FORWARD);
   return fwd === undefined ? MOQ_FORWARD_TRUE : (fwd.val as number);

--- a/src/moq/moqt.ts
+++ b/src/moq/moqt.ts
@@ -14,45 +14,49 @@ import {
   getArrayBufferByteLength,
 } from './buffer_utils.js';
 
-// MOQ Transport definitions — draft-ietf-moq-transport-16
+// MOQ Transport definitions — draft-ietf-moq-transport-18
 // https://datatracker.ietf.org/doc/draft-ietf-moq-transport/
 //
 // Since draft-15 the MOQT version is negotiated by the transport via ALPN (over
 // native QUIC) or WT-Available-Protocols (over WebTransport), not in-band in the
-// SETUP messages. The "version" is therefore an ALPN token string, offered to
+// SETUP message. The "version" is therefore an ALPN token string, offered to
 // WebTransport as a connection protocol (see Moq.init in ./moq.ts).
-export const MOQ_ALPN_DRAFT16_VERSION = 'moqt-16';
+export const MOQ_ALPN_DRAFT18_VERSION = 'moqt-18';
 
-export const MOQ_CURRENT_VERSION = MOQ_ALPN_DRAFT16_VERSION;
+export const MOQ_CURRENT_VERSION = MOQ_ALPN_DRAFT18_VERSION;
 
+// Identifies our implementation in the MOQT_IMPLEMENTATION setup option.
 export const MOQ_IMPLEMENTATION_NAME = 'moq-encoder-player';
 
 export const MOQ_USE_LITTLE_ENDIAN = false; // MoQ is big endian
 
-// Setup parameters (draft-16 §9.3.1). Same KVP namespace rules as draft-14.
-export const MOQ_SETUP_PARAMETER_PATH = 0x1;
-export const MOQ_SETUP_PARAMETER_MAX_REQUEST_ID = 0x2;
-export const MOQ_SETUP_MAX_AUTH_TOKEN_CACHE_SIZE = 0x4;
-export const MOQ_SETUP_PARAMETER_MOQT_IMPLEMENTATION = 0x7;
+// Setup Options (draft-18 §15.4) — separate namespace from Message Parameters.
+export const MOQ_SETUP_OPTION_PATH = 0x1;
+export const MOQ_SETUP_OPTION_AUTHORIZATION_TOKEN = 0x3;
+export const MOQ_SETUP_OPTION_MAX_AUTH_TOKEN_CACHE_SIZE = 0x4;
+export const MOQ_SETUP_OPTION_AUTHORITY = 0x5;
+export const MOQ_SETUP_OPTION_MOQT_IMPLEMENTATION = 0x7;
 
-// Message Parameters (draft-16 §13.2). Serialized as Key-Value-Pairs.
-export const MOQ_PARAMETER_DELIVERY_TIMEOUT = 0x02;
+// Message Parameters (draft-18 §15.7).
+export const MOQ_PARAMETER_OBJECT_DELIVERY_TIMEOUT = 0x02;
 export const MOQ_PARAMETER_AUTHORIZATION_TOKEN = 0x03;
+export const MOQ_PARAMETER_RENDEZVOUS_TIMEOUT = 0x04;
+export const MOQ_PARAMETER_SUBGROUP_DELIVERY_TIMEOUT = 0x06;
 export const MOQ_PARAMETER_EXPIRES = 0x08;
 export const MOQ_PARAMETER_LARGEST_OBJECT = 0x09;
+export const MOQ_PARAMETER_FILL_TIMEOUT = 0x0a;
 export const MOQ_PARAMETER_FORWARD = 0x10;
 export const MOQ_PARAMETER_SUBSCRIBER_PRIORITY = 0x20;
 export const MOQ_PARAMETER_SUBSCRIPTION_FILTER = 0x21;
 export const MOQ_PARAMETER_GROUP_ORDER = 0x22;
 export const MOQ_PARAMETER_NEW_GROUP_REQUEST = 0x32;
-export const MOQ_PARAMETER_MAX_CACHE_DURATION = 0x04;
+export const MOQ_PARAMETER_TRACK_NAMESPACE_PREFIX = 0x34;
 
 export const MOQ_MAX_PARAMS = 256;
 export const MOQ_MAX_ARRAY_LENGTH = 1024;
 export const MOQ_MAX_TUPLE_PARAMS = 32;
-export const MOQ_MAX_REQUEST_ID_NUM = 128;
 
-// REQUEST_ERROR codes (draft-16 §13.4.2) — subset used by this app.
+// REQUEST_ERROR codes (draft-18 §15.10.2) — subset used by this app.
 export const MOQ_REQUEST_ERROR_INTERNAL = 0x0;
 export const MOQ_REQUEST_ERROR_UNAUTHORIZED = 0x1;
 export const MOQ_REQUEST_ERROR_NOT_SUPPORTED = 0x3;
@@ -61,56 +65,55 @@ export const MOQ_REQUEST_ERROR_INVALID_RANGE = 0x11;
 // Back-compat alias used by the session layer when rejecting a SUBSCRIBE.
 export const MOQ_SUBSCRIPTION_ERROR_INTERNAL = MOQ_REQUEST_ERROR_INTERNAL;
 
-// MOQ FILTER TYPES (unchanged)
+// Filter types (draft-18 §5.1.2) — unchanged from draft-14.
 export const MOQ_FILTER_TYPE_NEXT_GROUP_START = 0x1;
 export const MOQ_FILTER_TYPE_LARGEST_OBJECT = 0x2;
 export const MOQ_FILTER_TYPE_ABSOLUTE_START = 0x3;
 export const MOQ_FILTER_TYPE_ABSOLUTE_RANGE = 0x4;
 
-// Object datagram type bits (draft-16 §10.3.1). Form 0b00X0XXXX.
-const MOQ_DATAGRAM_BIT_EXTENSIONS = 0x01;
+// Object datagram type bits (draft-18 §11.3.1). Form 0b00X0XXXX.
+const MOQ_DATAGRAM_BIT_PROPERTIES = 0x01;
 const MOQ_DATAGRAM_BIT_END_OF_GROUP = 0x02;
 const MOQ_DATAGRAM_BIT_ZERO_OBJECT_ID = 0x04;
 const MOQ_DATAGRAM_BIT_DEFAULT_PRIORITY = 0x08;
 const MOQ_DATAGRAM_BIT_STATUS = 0x20;
-const MOQ_DATAGRAM_ALLOWED_BITS = 0x2f; // 0x10 must be clear
+const MOQ_DATAGRAM_ALLOWED_BITS = 0x2f; // bits that may be set; 0x10 must be clear
 
-// Subgroup header type bits (draft-16 §10.4.2). Form 0b00X1XXXX (bit 0x10 set,
-// bits 0x40/0x80 clear — draft-16 has no FIRST_OBJECT bit and no 0x50-0x7F range).
-const MOQ_SUBGROUP_BIT_EXTENSIONS = 0x01;
+// Subgroup header type bits (draft-18 §11.4.2). Form 0b0XX1XXXX (bit 0x10 set).
+const MOQ_SUBGROUP_BIT_PROPERTIES = 0x01;
 const MOQ_SUBGROUP_SUBGROUP_ID_MODE_MASK = 0x06; // bits 1-2
 const MOQ_SUBGROUP_BIT_REQUIRED = 0x10;
 const MOQ_SUBGROUP_BIT_END_OF_GROUP = 0x08;
 const MOQ_SUBGROUP_BIT_DEFAULT_PRIORITY = 0x20;
-const MOQ_SUBGROUP_FORBIDDEN_BITS = 0xc0; // bits 6-7 must be clear
+const MOQ_SUBGROUP_BIT_FIRST_OBJECT = 0x40;
 const MOQ_SUBGROUP_ID_MODE_ABSENT_FIRST_OBJ = 1;
 const MOQ_SUBGROUP_ID_MODE_PRESENT = 2;
 
-// MOQ Messages (draft-16 §9 Table 1).
-export const MOQ_MESSAGE_CLIENT_SETUP = 0x20;
-export const MOQ_MESSAGE_SERVER_SETUP = 0x21;
+// MOQ Messages (draft-18 §10 Table 5).
+export const MOQ_MESSAGE_SETUP = 0x2f00; // doubles as the control uni-stream type
 export const MOQ_MESSAGE_GOAWAY = 0x10;
-export const MOQ_MESSAGE_MAX_REQUEST_ID = 0x15;
-export const MOQ_MESSAGE_REQUESTS_BLOCKED = 0x1a;
-export const MOQ_MESSAGE_REQUEST_OK = 0x7;
-export const MOQ_MESSAGE_REQUEST_ERROR = 0x5;
 export const MOQ_MESSAGE_REQUEST_UPDATE = 0x2;
 export const MOQ_MESSAGE_SUBSCRIBE = 0x3;
 export const MOQ_MESSAGE_SUBSCRIBE_OK = 0x4;
-export const MOQ_MESSAGE_UNSUBSCRIBE = 0xa;
-export const MOQ_MESSAGE_PUBLISH = 0x1d;
-export const MOQ_MESSAGE_PUBLISH_OK = 0x1e;
+export const MOQ_MESSAGE_REQUEST_ERROR = 0x5;
+export const MOQ_MESSAGE_PUBLISH_NAMESPACE = 0x6;
+export const MOQ_MESSAGE_REQUEST_OK = 0x7;
+export const MOQ_MESSAGE_NAMESPACE = 0x8;
 export const MOQ_MESSAGE_PUBLISH_DONE = 0xb;
+export const MOQ_MESSAGE_TRACK_STATUS = 0xd;
+export const MOQ_MESSAGE_NAMESPACE_DONE = 0xe;
+export const MOQ_MESSAGE_PUBLISH_BLOCKED = 0xf;
 export const MOQ_MESSAGE_FETCH = 0x16;
 export const MOQ_MESSAGE_FETCH_OK = 0x18;
-export const MOQ_MESSAGE_FETCH_CANCEL = 0x17;
-export const MOQ_MESSAGE_TRACK_STATUS = 0xd;
-export const MOQ_MESSAGE_PUBLISH_NAMESPACE = 0x6;
-export const MOQ_MESSAGE_NAMESPACE = 0x8;
-export const MOQ_MESSAGE_PUBLISH_NAMESPACE_DONE = 0x9;
-export const MOQ_MESSAGE_NAMESPACE_DONE = 0xe;
-export const MOQ_MESSAGE_PUBLISH_NAMESPACE_CANCEL = 0xc;
-export const MOQ_MESSAGE_SUBSCRIBE_NAMESPACE = 0x11;
+export const MOQ_MESSAGE_PUBLISH = 0x1d;
+export const MOQ_MESSAGE_SUBSCRIBE_NAMESPACE = 0x50;
+export const MOQ_MESSAGE_SUBSCRIBE_TRACKS = 0x51;
+
+// Unidirectional / datagram stream types (draft-18 §3.4).
+export const MOQ_STREAM_TYPE_FETCH_HEADER = 0x05;
+export const MOQ_STREAM_TYPE_SETUP = 0x2f00;
+export const MOQ_STREAM_TYPE_PADDING = 0x132b3e28;
+export const MOQ_DATAGRAM_TYPE_PADDING = 0x132b3e29;
 
 // MOQ PRIORITIES
 export const MOQ_PUBLISHER_PRIORITY_BASE_DEFAULT = 0xa;
@@ -130,14 +133,14 @@ export const MOQ_GROUP_ORDER_DESCENDING = 0x2;
 export const MOQ_FORWARD_FALSE = 0;
 export const MOQ_FORWARD_TRUE = 1;
 
-// Object status (draft-16 §10.2.1.1). NOT_EXISTS (0x1) and END_OF_SUBGROUP (0x5)
-// were removed in the draft-15..16 cleanup.
+// Object status (draft-18 §11.2.1.1). NOT_EXISTS (0x1) and END_OF_SUBGROUP (0x5)
+// were removed in the draft-15..18 cleanup.
 export const MOQ_OBJ_STATUS_NORMAL = 0x0;
 export const MOQ_OBJ_STATUS_END_OF_GROUP = 0x3;
 export const MOQ_OBJ_STATUS_END_OF_TRACK_AND_GROUP = 0x4;
 
-// Extension headers (Even types: value is a single varint. Odd types: value is a
-// length-prefixed byte buffer). draft-16 delta-encodes the Type (§1.4.2).
+// Object Properties (draft-18 §15.8). Renamed from "Extension Headers"; the
+// MoQMI media-interop types keep their values and ride the delta-encoded KVPs.
 export const MOQ_EXT_HEADER_TYPE_MOQMI_MEDIA_TYPE = 0x0a;
 export const MOQ_EXT_HEADER_TYPE_MOQMI_VIDEO_H264_IN_AVCC_METADATA = 0x15;
 export const MOQ_EXT_HEADER_TYPE_MOQMI_VIDEO_H264_IN_AVCC_EXTRADATA = 0x0d;
@@ -154,7 +157,7 @@ export const MOQ_EXT_HEADERS_SUPPORTED = [
   MOQ_EXT_HEADER_TYPE_MOQMI_AUDIO_AACLC_MPEG4_METADATA,
 ];
 
-// Authorization Token Alias Type (draft-16 §13.1)
+// Authorization Token Alias Type (draft-18 §15.5)
 export const MOQ_TOKEN_DELETE = 0x0;
 export const MOQ_TOKEN_REGISTER = 0x1;
 export const MOQ_TOKEN_USE_ALIAS = 0x2;
@@ -163,14 +166,14 @@ export const MOQ_TOKEN_USE_VALUE = 0x3;
 // Token type
 export const MOQ_TOKEN_TYPE_NEGOTIATED_OUT_OF_BAND = 0x0;
 
-// PUBLISH_DONE status codes (draft-16 §13.4.3)
+// PUBLISH_DONE status codes (draft-18 §15.10.3)
 export const MOQ_STATUS_INTERNAL_ERROR = 0x0;
 export const MOQ_STATUS_UNAUTHORIZED = 0x1;
 export const MOQ_STATUS_TRACK_ENDED = 0x2;
 export const MOQ_STATUS_SUBSCRIPTION_ENDED = 0x3;
 export const MOQ_STATUS_GOING_AWAY = 0x4;
-export const MOQ_STATUS_EXPIRED = 0x5;
-export const MOQ_STATUS_TOO_FAR_BEHIND = 0x6;
+export const MOQ_STATUS_TOO_FAR_BEHIND = 0x5;
+export const MOQ_STATUS_EXPIRED = 0x6;
 
 // Protocol value types
 
@@ -204,24 +207,25 @@ export interface Filter {
 
 export interface DatagramTypeOptions {
   isStatus: boolean;
-  extensionsPresent: boolean;
+  extensionsPresent: boolean; // Object Properties present
   isEndOfGroup: boolean;
   isObjIdPresent: boolean;
   isDefaultPriority: boolean;
 }
 
 export interface StreamHeaderOptions {
-  extensionsPresent: boolean;
+  extensionsPresent: boolean; // Object Properties present
   isEndOfGroup: boolean;
   subGroupIdPresent: boolean;
   isSubgroupIdFirstObjectId: boolean;
   isDefaultPriority: boolean;
+  isFirstObject: boolean;
 }
 
-// Parsed control messages (draft-16)
+// Parsed control messages (draft-18)
 
-export interface ParsedServerSetup {
-  parameters: KvPair[];
+export interface ParsedSetup {
+  options: KvPair[];
 }
 
 export interface ParsedSubscribe {
@@ -232,11 +236,10 @@ export interface ParsedSubscribe {
 }
 
 export interface ParsedSubscribeOk {
-  requestId: number;
   trackAlias: number;
   last?: Location;
   parameters: KvPair[];
-  extensions: KvPair[];
+  properties: KvPair[];
 }
 
 export interface ParsedPublish {
@@ -245,45 +248,24 @@ export interface ParsedPublish {
   trackName: string;
   trackAlias: number;
   parameters: KvPair[];
-  extensions: KvPair[];
-}
-
-export interface ParsedPublishOk {
-  reqId: number;
-  parameters: KvPair[];
+  properties: KvPair[];
 }
 
 export interface ParsedPublishDone {
-  requestId: number;
   statusCode: number;
   streamCount: number;
   errorReason: string;
 }
 
 export interface ParsedRequestOk {
-  requestId: number;
   parameters: KvPair[];
+  properties: KvPair[];
 }
 
 export interface ParsedRequestError {
-  requestId: number;
   errorCode: number;
   retryInterval: number;
   errorReason: string;
-}
-
-export interface ParsedRequestUpdate {
-  requestId: number;
-  existingRequestId: number;
-  parameters: KvPair[];
-}
-
-export interface ParsedUnsubscribe {
-  requestId: number;
-}
-
-export interface ParsedMaxRequestId {
-  maxRequestId: number;
 }
 
 export interface ParsedUnknown {
@@ -291,22 +273,20 @@ export interface ParsedUnknown {
 }
 
 export type MoqMessageData =
-  | ParsedServerSetup
+  | ParsedSetup
   | ParsedSubscribe
   | ParsedSubscribeOk
   | ParsedPublish
-  | ParsedPublishOk
   | ParsedPublishDone
   | ParsedRequestOk
   | ParsedRequestError
   | ParsedRequestUpdate
-  | ParsedUnsubscribe
-  | ParsedMaxRequestId
   | ParsedUnknown;
 
 export interface MoqMessage {
   type: number;
-  // `data` is one of the Parsed* shapes above, discriminated at runtime by `type`.
+  // `data` is one of the Parsed* shapes above, discriminated at runtime by
+  // `type`. Typed `any` because callers select fields based on `type`.
   data: any;
 }
 
@@ -331,7 +311,9 @@ export interface SubgroupObject {
 export interface MoqtState {
   // Kept loose: callers invoke `wt.createUnidirectionalStream(...)` etc.
   wt: any;
-  controlStream: WebTransportBidirectionalStream | null;
+  // draft-18 uses a pair of unidirectional control streams. We open one to send
+  // (controlWriter); the peer's incoming control stream is discovered by the
+  // session layer and stored in controlReader.
   controlWriter: WritableStream<Uint8Array> | null;
   controlReader: ReadableStream<Uint8Array> | null;
   multiObjectWritter: Record<string, WritableStreamDefaultWriter<Uint8Array>>;
@@ -341,7 +323,6 @@ export interface MoqtState {
 export function moqCreate(): MoqtState {
   return {
     wt: null,
-    controlStream: null,
     controlWriter: null,
     controlReader: null,
     multiObjectWritter: {},
@@ -380,25 +361,26 @@ export async function moqClose(moqt: MoqtState): Promise<void> {
     moqt.controlReader = null;
   }
   if (moqt.wt != null) {
+    // Race condition, relay closing too
     await moqt.wt.close();
   }
   moqt.wt = null;
-  moqt.controlStream = null;
+  moqt.controlWriter = null;
   moqt.controlReader = null;
   moqt.datagramsReader = null;
 }
 
-// MOQ control stream — draft-16 keeps a client-initiated bidirectional stream.
+// MOQ control stream — draft-18 opens a unidirectional stream that begins with
+// the SETUP message (stream type 0x2F00 == SETUP message type).
 export async function moqCreateControlStream(moqt: MoqtState): Promise<void> {
   if (moqt.wt === null) {
     throw new Error('WT session is NULL when we tried to create MOQ');
   }
-  if (moqt.controlReader != null || moqt.controlWriter != null) {
-    throw new Error('controlReader/controlWriter not null, dirty state from a previous session');
+  if (moqt.controlWriter != null) {
+    throw new Error('controlWriter is NOT null, dirty state from a previous session');
   }
-  moqt.controlStream = await moqt.wt.createBidirectionalStream();
-  moqt.controlWriter = moqt.controlStream.writable;
-  moqt.controlReader = moqt.controlStream.readable;
+  // createUnidirectionalStream() resolves to the WritableStream send side.
+  moqt.controlWriter = await moqt.wt.createUnidirectionalStream();
 }
 
 // ---- buffer cursor used to parse length-bounded control messages -----------
@@ -419,6 +401,9 @@ class BufReader {
     );
     this.off += r.byteLength;
     return r.num as number;
+  }
+  readU8(): number {
+    return this.bytes[this.off++];
   }
   readU16(): number {
     const v = new DataView(this.bytes.buffer, this.bytes.byteOffset + this.off, 2).getUint16(
@@ -450,22 +435,25 @@ class BufReader {
   }
 }
 
-// ---- CLIENT_SETUP / SERVER_SETUP --------------------------------------------
+// ---- SETUP ------------------------------------------------------------------
 
-function moqCreateClientSetupMessageBytes(): Uint8Array {
-  const params: KvPair[] = [
-    moqCreateKvPair(MOQ_SETUP_PARAMETER_MAX_REQUEST_ID, MOQ_MAX_REQUEST_ID_NUM),
-    moqCreateKvPair(MOQ_SETUP_PARAMETER_MOQT_IMPLEMENTATION, MOQ_IMPLEMENTATION_NAME),
-  ];
-  return frameControlMessage(MOQ_MESSAGE_CLIENT_SETUP, [moqCreateParametersBytes(params)]);
+function moqCreateSetupMessageBytes(): Uint8Array {
+  const options = moqCreateKvpDeltaBytes([
+    moqCreateKvPair(MOQ_SETUP_OPTION_MOQT_IMPLEMENTATION, MOQ_IMPLEMENTATION_NAME),
+  ]);
+  return concatBuffer([
+    numberToVarInt(MOQ_MESSAGE_SETUP),
+    numberTo2BytesArray(options.byteLength, MOQ_USE_LITTLE_ENDIAN),
+    options,
+  ]);
 }
 
-export async function moqSendClientSetup(writerStream: WritableStream<Uint8Array>): Promise<void> {
-  return moqSendToStream(writerStream, moqCreateClientSetupMessageBytes());
+export async function moqSendSetup(writerStream: WritableStream<Uint8Array>): Promise<void> {
+  return moqSendToStream(writerStream, moqCreateSetupMessageBytes());
 }
 
-function moqParseServerSetup(r: BufReader): ParsedServerSetup {
-  return { parameters: moqReadParameters(r) };
+function moqParseSetup(r: BufReader): ParsedSetup {
+  return { options: moqReadKvpDelta(r, r.remaining()) };
 }
 
 // ---- PUBLISH ----------------------------------------------------------------
@@ -498,16 +486,24 @@ function moqCreatePublishMessageBytes(
   if (forward === MOQ_FORWARD_FALSE) {
     params.push(moqCreateKvPair(MOQ_PARAMETER_FORWARD, MOQ_FORWARD_FALSE));
   }
-  pushAuthParam(params, authInfo);
+  if (authInfo != undefined && authInfo != '') {
+    params.push(
+      moqCreateKvPair(
+        MOQ_PARAMETER_AUTHORIZATION_TOKEN,
+        moqCreateUseValueTokenFromString(authInfo as string),
+      ),
+    );
+  }
 
   const msg: Uint8Array[] = [
     numberToVarInt(reqId),
     moqCreateTupleBytes(namespace),
     moqCreateStringBytes(name),
     numberToVarInt(trackAlias),
-    moqCreateParametersBytes(params),
-    // Track Extensions (empty)
+    moqCreateMessageParametersBytes(params),
+    // Track Properties (empty)
   ];
+
   return frameControlMessage(MOQ_MESSAGE_PUBLISH, msg);
 }
 
@@ -516,9 +512,9 @@ function moqParsePublish(r: BufReader): ParsedPublish {
   const namespace = r.readNamespace();
   const trackName = r.readString();
   const trackAlias = r.readVarint();
-  const parameters = moqReadParameters(r);
-  const extensions = moqReadKvpListRest(r);
-  return { requestId, namespace, trackName, trackAlias, parameters, extensions };
+  const parameters = moqReadMessageParameters(r);
+  const properties = moqReadKvpDelta(r, r.remaining());
+  return { requestId, namespace, trackName, trackAlias, parameters, properties };
 }
 
 // ---- PUBLISH_NAMESPACE ------------------------------------------------------
@@ -530,34 +526,31 @@ export async function moqSendPublishNamespace(
   authInfo: string | number | undefined,
 ): Promise<void> {
   const params: KvPair[] = [];
-  pushAuthParam(params, authInfo);
+  if (authInfo != undefined && authInfo != '') {
+    params.push(
+      moqCreateKvPair(
+        MOQ_PARAMETER_AUTHORIZATION_TOKEN,
+        moqCreateUseValueTokenFromString(authInfo as string),
+      ),
+    );
+  }
   const msg: Uint8Array[] = [
     numberToVarInt(reqId),
     moqCreateTupleBytes(namespace),
-    moqCreateParametersBytes(params),
+    moqCreateMessageParametersBytes(params),
   ];
   return moqSendToStream(writerStream, frameControlMessage(MOQ_MESSAGE_PUBLISH_NAMESPACE, msg));
-}
-
-// ---- PUBLISH_OK (parsed; sent by the subscriber peer) -----------------------
-
-function moqParsePublishOk(r: BufReader): ParsedPublishOk {
-  const reqId = r.readVarint();
-  const parameters = moqReadParameters(r);
-  return { reqId, parameters };
 }
 
 // ---- PUBLISH_DONE -----------------------------------------------------------
 
 export async function moqSendPublishDone(
   writerStream: WritableStream<Uint8Array>,
-  requestId: number,
   statusCode: number,
   streamCount: number,
   reason: string,
 ): Promise<void> {
   const msg: Uint8Array[] = [
-    numberToVarInt(requestId),
     numberToVarInt(statusCode),
     numberToVarInt(streamCount),
     moqCreateStringBytes(reason),
@@ -567,7 +560,6 @@ export async function moqSendPublishDone(
 
 function moqParsePublishDone(r: BufReader): ParsedPublishDone {
   return {
-    requestId: r.readVarint(),
     statusCode: r.readVarint(),
     streamCount: r.readVarint(),
     errorReason: r.readString(),
@@ -603,14 +595,22 @@ function moqCreateSubscribeMessageBytes(
       numberToVarInt(MOQ_FILTER_TYPE_LARGEST_OBJECT),
     ),
   );
-  pushAuthParam(params, authInfo);
+  if (authInfo != undefined && authInfo != '') {
+    params.push(
+      moqCreateKvPair(
+        MOQ_PARAMETER_AUTHORIZATION_TOKEN,
+        moqCreateUseValueTokenFromString(authInfo as string),
+      ),
+    );
+  }
 
   const msg: Uint8Array[] = [
     numberToVarInt(requestId),
     moqCreateTupleBytes(trackNamespace),
     moqCreateStringBytes(trackName),
-    moqCreateParametersBytes(params),
+    moqCreateMessageParametersBytes(params),
   ];
+
   return frameControlMessage(MOQ_MESSAGE_SUBSCRIBE, msg);
 }
 
@@ -618,7 +618,7 @@ function moqParseSubscribe(r: BufReader): ParsedSubscribe {
   const requestId = r.readVarint();
   const namespace = r.readNamespace();
   const trackName = r.readString();
-  const parameters = moqReadParameters(r);
+  const parameters = moqReadMessageParameters(r);
   return { requestId, namespace, trackName, parameters };
 }
 
@@ -626,19 +626,17 @@ function moqParseSubscribe(r: BufReader): ParsedSubscribe {
 
 export async function moqSendSubscribeOk(
   writerStream: WritableStream<Uint8Array>,
-  requestId: number,
   trackAlias: number,
   lastGroupSent?: number,
   lastObjSent?: number,
 ): Promise<void> {
   return moqSendToStream(
     writerStream,
-    moqCreateSubscribeOkMessageBytes(requestId, trackAlias, lastGroupSent, lastObjSent),
+    moqCreateSubscribeOkMessageBytes(trackAlias, lastGroupSent, lastObjSent),
   );
 }
 
 function moqCreateSubscribeOkMessageBytes(
-  requestId: number,
   trackAlias: number,
   lastGroupSent?: number,
   lastObjSent?: number,
@@ -650,20 +648,18 @@ function moqCreateSubscribeOkMessageBytes(
     );
   }
   const msg: Uint8Array[] = [
-    numberToVarInt(requestId),
     numberToVarInt(trackAlias),
-    moqCreateParametersBytes(params),
-    // Track Extensions (empty)
+    moqCreateMessageParametersBytes(params),
+    // Track Properties (empty)
   ];
   return frameControlMessage(MOQ_MESSAGE_SUBSCRIBE_OK, msg);
 }
 
 function moqParseSubscribeOk(r: BufReader): ParsedSubscribeOk {
-  const requestId = r.readVarint();
   const trackAlias = r.readVarint();
-  const parameters = moqReadParameters(r);
-  const extensions = moqReadKvpListRest(r);
-  const ret: ParsedSubscribeOk = { requestId, trackAlias, parameters, extensions };
+  const parameters = moqReadMessageParameters(r);
+  const properties = moqReadKvpDelta(r, r.remaining());
+  const ret: ParsedSubscribeOk = { trackAlias, parameters, properties };
   const largest = parameters.find((p) => p.name === MOQ_PARAMETER_LARGEST_OBJECT);
   if (largest !== undefined) {
     ret.last = largest.val as Location;
@@ -673,28 +669,26 @@ function moqParseSubscribeOk(r: BufReader): ParsedSubscribeOk {
 
 // ---- REQUEST_OK / REQUEST_ERROR --------------------------------------------
 
-export async function moqSendRequestOk(
-  writerStream: WritableStream<Uint8Array>,
-  requestId: number,
-): Promise<void> {
-  const msg: Uint8Array[] = [numberToVarInt(requestId), moqCreateParametersBytes([])];
+export async function moqSendRequestOk(writerStream: WritableStream<Uint8Array>): Promise<void> {
+  const msg: Uint8Array[] = [
+    moqCreateMessageParametersBytes([]),
+    // Track Properties (empty)
+  ];
   return moqSendToStream(writerStream, frameControlMessage(MOQ_MESSAGE_REQUEST_OK, msg));
 }
 
 function moqParseRequestOk(r: BufReader): ParsedRequestOk {
-  const requestId = r.readVarint();
-  const parameters = moqReadParameters(r);
-  return { requestId, parameters };
+  const parameters = moqReadMessageParameters(r);
+  const properties = moqReadKvpDelta(r, r.remaining());
+  return { parameters, properties };
 }
 
 export async function moqSendRequestError(
   writerStream: WritableStream<Uint8Array>,
-  requestId: number,
   errorCode: number,
   reason: string,
 ): Promise<void> {
   const msg: Uint8Array[] = [
-    numberToVarInt(requestId),
     numberToVarInt(errorCode),
     numberToVarInt(0), // Retry Interval: 0 => do not retry
     moqCreateStringBytes(reason),
@@ -703,42 +697,31 @@ export async function moqSendRequestError(
 }
 
 function moqParseRequestError(r: BufReader): ParsedRequestError {
-  return {
-    requestId: r.readVarint(),
-    errorCode: r.readVarint(),
-    retryInterval: r.readVarint(),
-    errorReason: r.readString(),
-  };
+  const errorCode = r.readVarint();
+  const retryInterval = r.readVarint();
+  const errorReason = r.readString();
+  // A Redirect structure may follow when errorCode === REDIRECT; ignored here.
+  return { errorCode, retryInterval, errorReason };
 }
 
 // ---- REQUEST_UPDATE ---------------------------------------------------------
 
-function moqParseRequestUpdate(r: BufReader): ParsedRequestUpdate {
-  return {
-    requestId: r.readVarint(),
-    existingRequestId: r.readVarint(),
-    parameters: moqReadParameters(r),
-  };
+export interface ParsedRequestUpdate {
+  requestId: number;
+  parameters: KvPair[];
 }
 
-// ---- UNSUBSCRIBE ------------------------------------------------------------
-
-export async function moqSendUnSubscribe(
+export async function moqSendRequestUpdate(
   writerStream: WritableStream<Uint8Array>,
   requestId: number,
+  params: KvPair[] = [],
 ): Promise<void> {
-  const msg: Uint8Array[] = [numberToVarInt(requestId)];
-  return moqSendToStream(writerStream, frameControlMessage(MOQ_MESSAGE_UNSUBSCRIBE, msg));
+  const msg: Uint8Array[] = [numberToVarInt(requestId), moqCreateMessageParametersBytes(params)];
+  return moqSendToStream(writerStream, frameControlMessage(MOQ_MESSAGE_REQUEST_UPDATE, msg));
 }
 
-function moqParseUnSubscribe(r: BufReader): ParsedUnsubscribe {
-  return { requestId: r.readVarint() };
-}
-
-// ---- MAX_REQUEST_ID ---------------------------------------------------------
-
-function moqParseMaxRequestId(r: BufReader): ParsedMaxRequestId {
-  return { maxRequestId: r.readVarint() };
+function moqParseRequestUpdate(r: BufReader): ParsedRequestUpdate {
+  return { requestId: r.readVarint(), parameters: moqReadMessageParameters(r) };
 }
 
 // ---- UNKNOWN ----------------------------------------------------------------
@@ -749,16 +732,29 @@ function moqParseUnknown(r: BufReader): ParsedUnknown {
 
 // ---- control message dispatch ----------------------------------------------
 
+// Read a leading variable-length type (stream type or control message type).
+export function moqReadVarintType(readerStream: ReadableStream<Uint8Array>): Promise<number> {
+  return varIntToNumberOrThrow(readerStream);
+}
+
 export async function moqParseMsg(readerStream: ReadableStream<Uint8Array>): Promise<MoqMessage> {
-  const msgType = await varIntToNumberOrThrow(readerStream);
+  const msgType = await moqReadVarintType(readerStream);
+  return moqParseControlMessageWithType(readerStream, msgType);
+}
+
+// Parse a control/request message whose leading type varint was already read.
+export async function moqParseControlMessageWithType(
+  readerStream: ReadableStream<Uint8Array>,
+  msgType: number,
+): Promise<MoqMessage> {
   const len = await moqIntReadBytesOrThrow(readerStream, 2);
   const payload = len > 0 ? await buffReadOrThrow(readerStream, len) : new Uint8Array(0);
   const r = new BufReader(payload);
 
   let data: MoqMessageData;
   switch (msgType) {
-    case MOQ_MESSAGE_SERVER_SETUP:
-      data = moqParseServerSetup(r);
+    case MOQ_MESSAGE_SETUP:
+      data = moqParseSetup(r);
       break;
     case MOQ_MESSAGE_SUBSCRIBE:
       data = moqParseSubscribe(r);
@@ -768,9 +764,6 @@ export async function moqParseMsg(readerStream: ReadableStream<Uint8Array>): Pro
       break;
     case MOQ_MESSAGE_PUBLISH:
       data = moqParsePublish(r);
-      break;
-    case MOQ_MESSAGE_PUBLISH_OK:
-      data = moqParsePublishOk(r);
       break;
     case MOQ_MESSAGE_PUBLISH_DONE:
       data = moqParsePublishDone(r);
@@ -783,12 +776,6 @@ export async function moqParseMsg(readerStream: ReadableStream<Uint8Array>): Pro
       break;
     case MOQ_MESSAGE_REQUEST_UPDATE:
       data = moqParseRequestUpdate(r);
-      break;
-    case MOQ_MESSAGE_UNSUBSCRIBE:
-      data = moqParseUnSubscribe(r);
-      break;
-    case MOQ_MESSAGE_MAX_REQUEST_ID:
-      data = moqParseMaxRequestId(r);
       break;
     default:
       data = moqParseUnknown(r);
@@ -803,9 +790,13 @@ function moqCreateSubgroupHeaderBytes(
   groupSeq: number,
   publisherPriority: number,
 ): Uint8Array {
-  // Extensions present (MoQMI always carries them), subgroup id present,
-  // explicit priority. draft-16 has no FIRST_OBJECT bit.
-  const type = getSubgroupHeaderType({ extensionsPresent: true, subGroupIdPresent: true });
+  // Properties present (MoQMI always carries them), subgroup id present, first
+  // object of the subgroup (we are the original publisher), explicit priority.
+  const type = getSubgroupHeaderType({
+    propertiesPresent: true,
+    subGroupIdPresent: true,
+    isFirstObject: true,
+  });
   return concatBuffer([
     numberToVarInt(type),
     numberToVarInt(trackAlias),
@@ -821,7 +812,7 @@ function moqCreateObjectEndOfGroupBytes(
 ): Uint8Array {
   return concatBuffer([
     numberToVarInt(objSeqDelta), // Object ID delta
-    moqCreateExtensionsBytes(extensionHeaders), // length-prefixed (0 when empty)
+    moqCreatePropertiesBytes(extensionHeaders), // length-prefixed (0 when empty)
     numberToVarInt(0), // Object payload length
     numberToVarInt(MOQ_OBJ_STATUS_END_OF_GROUP),
   ]);
@@ -834,7 +825,7 @@ function moqCreateObjectSubgroupBytes(
 ): Uint8Array {
   const msg: Array<Uint8Array | BufferSource> = [];
   msg.push(numberToVarInt(objSeqDelta));
-  msg.push(moqCreateExtensionsBytes(extensionHeaders)); // header has EXTENSIONS bit set
+  msg.push(moqCreatePropertiesBytes(extensionHeaders)); // header has PROPERTIES bit set
   if (data != undefined && data.byteLength > 0) {
     msg.push(numberToVarInt(data.byteLength));
     msg.push(data);
@@ -858,7 +849,11 @@ function moqCreateObjectPerDatagramBytes(
   const hasHeaders = extensionHeaders != undefined && extensionHeaders.length > 0;
   const hasData = data != undefined && data.byteLength > 0;
 
-  const type = getDatagramType({ isStatus: !hasData, extensionsPresent: hasHeaders, isEndOfGroup });
+  const type = getDatagramType({
+    isStatus: !hasData,
+    propertiesPresent: hasHeaders,
+    isEndOfGroup,
+  });
 
   msg.push(numberToVarInt(type));
   msg.push(numberToVarInt(trackAlias));
@@ -866,7 +861,7 @@ function moqCreateObjectPerDatagramBytes(
   msg.push(numberToVarInt(objSeq));
   msg.push(numberToSingleByteArray(publisherPriority));
   if (hasHeaders) {
-    msg.push(moqCreateExtensionsBytes(extensionHeaders));
+    msg.push(moqCreatePropertiesBytes(extensionHeaders));
   }
   if (hasData) {
     msg.push(data);
@@ -938,6 +933,14 @@ export async function moqParseObjectHeader(
   readerStream: ReadableStream<Uint8Array>,
 ): Promise<ObjectHeader> {
   const type = await varIntToNumberOrThrow(readerStream);
+  return moqParseObjectHeaderWithType(readerStream, type);
+}
+
+// Parse an object/subgroup header whose leading type varint was already read.
+export async function moqParseObjectHeaderWithType(
+  readerStream: ReadableStream<Uint8Array>,
+  type: number,
+): Promise<ObjectHeader> {
   if (!isMoqObjectStreamHeaderType(type) && !isMoqObjectDatagramType(type)) {
     throw new Error(`OBJECT is not any known object type, got ${type}`);
   }
@@ -953,7 +956,7 @@ export async function moqParseObjectHeader(
       ? MOQ_PUBLISHER_PRIORITY_BASE_DEFAULT
       : await moqIntReadBytesOrThrow(readerStream, 1);
     if (options.extensionsPresent) {
-      ret.extensionHeaders = await moqReadExtensionsFromStream(readerStream);
+      ret.extensionHeaders = await moqReadProperties(readerStream);
     }
     return ret;
   }
@@ -981,7 +984,7 @@ export async function moqParseObjectFromSubgroupHeader(
   const objSeq = await varIntToNumberOrThrow(readerStream);
   let extensionHeaders: KvPair[] = [];
   if (typeDecoded.extensionsPresent) {
-    extensionHeaders = await moqReadExtensionsFromStream(readerStream);
+    extensionHeaders = await moqReadProperties(readerStream);
   }
   const payloadLength = await varIntToNumberOrThrow(readerStream);
   const ret: SubgroupObject = { objSeq, payloadLength, extensionHeaders };
@@ -997,7 +1000,7 @@ export function getTrackFullName(namespace: string, trackName: string): string {
   return namespace + trackName;
 }
 
-// Frame a control message: [type varint][u16 length][body...].
+// Frame a control/request message: [type varint][u16 length][body...].
 function frameControlMessage(type: number, body: Uint8Array[]): Uint8Array {
   const totalLength = getArrayBufferByteLength(body);
   return concatBuffer([
@@ -1029,24 +1032,113 @@ export function moqCreateKvPair(name: number, val: KvPairValue): KvPair {
   return { name, val };
 }
 
-function pushAuthParam(params: KvPair[], authInfo: string | number | undefined): void {
-  if (authInfo != undefined && authInfo != '') {
-    params.push(
-      moqCreateKvPair(
-        MOQ_PARAMETER_AUTHORIZATION_TOKEN,
-        moqCreateUseValueTokenFromString(authInfo as string),
-      ),
-    );
+// ---- Message Parameters (draft-18 §10.2) -----------------------------------
+//
+// Type-delta encoded, count-bounded; each parameter Type has a fixed value
+// encoding. Unknown parameter types are a protocol violation (we throw).
+
+const PARAM_ENC_UINT8 = 1;
+const PARAM_ENC_VARINT = 2;
+const PARAM_ENC_LOCATION = 3;
+const PARAM_ENC_LENPREFIXED = 4;
+
+const MESSAGE_PARAM_ENCODING: Record<number, number> = {
+  [MOQ_PARAMETER_OBJECT_DELIVERY_TIMEOUT]: PARAM_ENC_VARINT,
+  [MOQ_PARAMETER_AUTHORIZATION_TOKEN]: PARAM_ENC_LENPREFIXED,
+  [MOQ_PARAMETER_RENDEZVOUS_TIMEOUT]: PARAM_ENC_VARINT,
+  [MOQ_PARAMETER_SUBGROUP_DELIVERY_TIMEOUT]: PARAM_ENC_VARINT,
+  [MOQ_PARAMETER_EXPIRES]: PARAM_ENC_VARINT,
+  [MOQ_PARAMETER_LARGEST_OBJECT]: PARAM_ENC_LOCATION,
+  [MOQ_PARAMETER_FILL_TIMEOUT]: PARAM_ENC_VARINT,
+  [MOQ_PARAMETER_FORWARD]: PARAM_ENC_UINT8,
+  [MOQ_PARAMETER_SUBSCRIBER_PRIORITY]: PARAM_ENC_UINT8,
+  [MOQ_PARAMETER_SUBSCRIPTION_FILTER]: PARAM_ENC_LENPREFIXED,
+  [MOQ_PARAMETER_GROUP_ORDER]: PARAM_ENC_UINT8,
+  [MOQ_PARAMETER_NEW_GROUP_REQUEST]: PARAM_ENC_VARINT,
+  [MOQ_PARAMETER_TRACK_NAMESPACE_PREFIX]: PARAM_ENC_LENPREFIXED,
+};
+
+function moqCreateMessageParametersBytes(kvParams: KvPair[]): Uint8Array {
+  const sorted = [...kvParams].sort((a, b) => a.name - b.name);
+  const parts: Array<Uint8Array | BufferSource> = [numberToVarInt(sorted.length)];
+  let prevType = 0;
+  for (const p of sorted) {
+    parts.push(numberToVarInt(p.name - prevType));
+    prevType = p.name;
+    parts.push(encodeMessageParamValue(p.name, p.val));
   }
+  return concatBuffer(parts);
 }
 
-// ---- Key-Value-Pairs (draft-16 §1.4.2) -------------------------------------
+function encodeMessageParamValue(type: number, val: KvPairValue): Uint8Array {
+  const enc = MESSAGE_PARAM_ENCODING[type];
+  if (enc === PARAM_ENC_UINT8) {
+    return numberToSingleByteArray(val as number);
+  }
+  if (enc === PARAM_ENC_VARINT) {
+    return numberToVarInt(val as number);
+  }
+  if (enc === PARAM_ENC_LOCATION) {
+    const loc = val as Location;
+    return concatBuffer([numberToVarInt(loc.group), numberToVarInt(loc.obj)]);
+  }
+  if (enc === PARAM_ENC_LENPREFIXED) {
+    let bytes: Uint8Array;
+    if (type === MOQ_PARAMETER_AUTHORIZATION_TOKEN) {
+      bytes = moqSerializeTokenStruct(val as Token);
+    } else if (val instanceof Uint8Array) {
+      bytes = val;
+    } else if (val instanceof ArrayBuffer) {
+      bytes = new Uint8Array(val);
+    } else {
+      throw new Error(`Message param ${type} expects a byte value`);
+    }
+    return concatBuffer([numberToVarInt(bytes.byteLength), bytes]);
+  }
+  throw new Error(`Unknown message parameter type ${type}`);
+}
+
+function moqReadMessageParameters(r: BufReader): KvPair[] {
+  const count = r.readVarint();
+  const out: KvPair[] = [];
+  let prevType = 0;
+  for (let i = 0; i < count; i++) {
+    const type = prevType + r.readVarint();
+    prevType = type;
+    out.push(moqCreateKvPair(type, decodeMessageParamValue(r, type)));
+  }
+  return out;
+}
+
+function decodeMessageParamValue(r: BufReader, type: number): KvPairValue {
+  const enc = MESSAGE_PARAM_ENCODING[type];
+  if (enc === PARAM_ENC_UINT8) {
+    return r.readU8();
+  }
+  if (enc === PARAM_ENC_VARINT) {
+    return r.readVarint();
+  }
+  if (enc === PARAM_ENC_LOCATION) {
+    return r.readLocation();
+  }
+  if (enc === PARAM_ENC_LENPREFIXED) {
+    const len = r.readVarint();
+    const bytes = r.readBytes(len);
+    if (type === MOQ_PARAMETER_AUTHORIZATION_TOKEN) {
+      return moqParseTokenStruct(bytes);
+    }
+    return new Uint8Array(bytes); // copy out of the shared buffer view
+  }
+  throw new Error(`Unknown message parameter type ${type}`);
+}
+
+// ---- Key-Value-Pairs (draft-18 §1.4.3) -------------------------------------
 //
 // Delta-type encoded; Length present only when the (absolute) Type is odd. Used
-// for Setup/Message Parameters (count-bounded) and Extension Headers
-// (length-bounded). Even types carry a varint; odd types carry length+bytes.
+// for Setup Options, Track Properties and Object Properties.
 
-function moqEncodeKvpList(kvParams: KvPair[]): Uint8Array {
+// Serialize KVPs (no outer length) — used for Setup Options / Track Properties.
+function moqCreateKvpDeltaBytes(kvParams: KvPair[]): Uint8Array {
   const sorted = [...kvParams].sort((a, b) => a.name - b.name);
   const parts: Array<Uint8Array | BufferSource> = [];
   let prevType = 0;
@@ -1065,93 +1157,52 @@ function encodeKvpValue(name: number, val: KvPairValue): Uint8Array {
     }
     return numberToVarInt(val);
   }
-  // Odd type: length-prefixed bytes (string, raw bytes, Token, or Location).
+  // Odd type: length-prefixed bytes (or a UTF-8 string).
   let bytes: Uint8Array;
-  if (name === MOQ_PARAMETER_AUTHORIZATION_TOKEN && isToken(val)) {
-    bytes = moqSerializeTokenStruct(val);
-  } else if (name === MOQ_PARAMETER_LARGEST_OBJECT && isLocation(val)) {
-    bytes = concatBuffer([numberToVarInt(val.group), numberToVarInt(val.obj)]);
-  } else if (typeof val === 'string') {
+  if (typeof val === 'string') {
     bytes = new TextEncoder().encode(val);
   } else if (val instanceof Uint8Array) {
     bytes = val;
   } else if (val instanceof ArrayBuffer) {
     bytes = new Uint8Array(val);
   } else {
-    throw new Error(`Odd KVP type ${name} must carry a string/byte/Token/Location value`);
+    throw new Error('Odd KVP type must carry a string or byte value');
   }
   return concatBuffer([numberToVarInt(bytes.byteLength), bytes]);
 }
 
-function decodeKvpValue(r: BufReader, type: number): KvPairValue {
-  if (type % 2 === 0) {
-    return r.readVarint();
-  }
-  const len = r.readVarint();
-  const bytes = r.readBytes(len);
-  if (type === MOQ_PARAMETER_AUTHORIZATION_TOKEN) {
-    return moqParseTokenStruct(bytes);
-  }
-  if (type === MOQ_PARAMETER_LARGEST_OBJECT) {
-    const lr = new BufReader(bytes);
-    return lr.readLocation();
-  }
-  // Return a standalone ArrayBuffer (copied out of the shared view). Consumers
-  // such as the MoQMI packager read these values via varIntToNumbeFromBuffer /
-  // DataView, which require an ArrayBuffer rather than a typed-array view.
-  return bytes.slice().buffer;
-}
-
-// Parameters: a varint count followed by delta-encoded KVPs.
-function moqCreateParametersBytes(kvParams: KvPair[]): Uint8Array {
-  return concatBuffer([numberToVarInt(kvParams.length), moqEncodeKvpList(kvParams)]);
-}
-
-function moqReadParameters(r: BufReader): KvPair[] {
-  const count = r.readVarint();
-  const out: KvPair[] = [];
-  let prevType = 0;
-  for (let i = 0; i < count; i++) {
-    const type = prevType + r.readVarint();
-    prevType = type;
-    out.push(moqCreateKvPair(type, decodeKvpValue(r, type)));
-  }
-  return out;
-}
-
-// Extension Headers: a varint byte-length followed by delta-encoded KVPs.
-function moqCreateExtensionsBytes(kvParams: KvPair[]): Uint8Array {
-  const inner = moqEncodeKvpList(kvParams);
+// Object Properties: a length prefix followed by delta-encoded KVPs.
+function moqCreatePropertiesBytes(kvParams: KvPair[]): Uint8Array {
+  const inner = moqCreateKvpDeltaBytes(kvParams);
   return concatBuffer([numberToVarInt(inner.byteLength), inner]);
 }
 
-function moqReadKvpListByteLen(r: BufReader, byteLen: number): KvPair[] {
+// Parse delta-encoded KVPs from a buffer cursor up to `byteLen` bytes.
+function moqReadKvpDelta(r: BufReader, byteLen: number): KvPair[] {
   const out: KvPair[] = [];
   const end = r.off + byteLen;
   let prevType = 0;
   while (r.off < end) {
     const type = prevType + r.readVarint();
     prevType = type;
-    out.push(moqCreateKvPair(type, decodeKvpValue(r, type)));
+    if (type % 2 === 0) {
+      out.push(moqCreateKvPair(type, r.readVarint()));
+    } else {
+      const size = r.readVarint();
+      out.push(moqCreateKvPair(type, new Uint8Array(r.readBytes(size))));
+    }
   }
   return out;
 }
 
-// Track Extensions span the rest of the control message.
-function moqReadKvpListRest(r: BufReader): KvPair[] {
-  return moqReadKvpListByteLen(r, r.remaining());
-}
-
-// Object Extension Headers read from a data stream (length-prefixed delta KVPs).
-async function moqReadExtensionsFromStream(
-  readerStream: ReadableStream<Uint8Array>,
-): Promise<KvPair[]> {
+// Parse Object Properties (length-prefixed delta KVPs) from a data stream.
+async function moqReadProperties(readerStream: ReadableStream<Uint8Array>): Promise<KvPair[]> {
   const totalLen = await varIntToNumberOrThrow(readerStream);
   if (totalLen <= 0) {
     return [];
   }
   const buf = await buffReadOrThrow(readerStream, totalLen);
-  return moqReadKvpListByteLen(new BufReader(buf), buf.byteLength);
+  return moqReadKvpDelta(new BufReader(buf), buf.byteLength);
 }
 
 async function buffReadOrThrow(
@@ -1184,14 +1235,6 @@ async function moqIntReadBytesOrThrow(
 
 // ---- Authorization Token ----------------------------------------------------
 
-function isToken(val: KvPairValue): val is Token {
-  return typeof val === 'object' && val !== null && 'aliasType' in val && 'tokenType' in val;
-}
-
-function isLocation(val: KvPairValue): val is Location {
-  return typeof val === 'object' && val !== null && 'group' in val && 'obj' in val;
-}
-
 function moqCreateUseValueTokenFromString(str: string): Token {
   return {
     aliasType: MOQ_TOKEN_USE_VALUE,
@@ -1200,7 +1243,7 @@ function moqCreateUseValueTokenFromString(str: string): Token {
   };
 }
 
-// Token struct (no outer length; the KVP Length provides it).
+// Token struct (no outer length; the parameter provides the length).
 function moqSerializeTokenStruct(token: Token): Uint8Array {
   if (token.aliasType != MOQ_TOKEN_USE_VALUE) {
     throw new Error('Only USE_VALUE token supported');
@@ -1292,7 +1335,7 @@ export function moqDecodeDatagramType(type: number): DatagramTypeOptions {
   }
   return {
     isStatus: (type & MOQ_DATAGRAM_BIT_STATUS) !== 0,
-    extensionsPresent: (type & MOQ_DATAGRAM_BIT_EXTENSIONS) !== 0,
+    extensionsPresent: (type & MOQ_DATAGRAM_BIT_PROPERTIES) !== 0,
     isEndOfGroup: (type & MOQ_DATAGRAM_BIT_END_OF_GROUP) !== 0,
     isObjIdPresent: (type & MOQ_DATAGRAM_BIT_ZERO_OBJECT_ID) === 0,
     isDefaultPriority: (type & MOQ_DATAGRAM_BIT_DEFAULT_PRIORITY) !== 0,
@@ -1301,7 +1344,7 @@ export function moqDecodeDatagramType(type: number): DatagramTypeOptions {
 
 function getDatagramType(opts: {
   isStatus: boolean;
-  extensionsPresent: boolean;
+  propertiesPresent: boolean;
   isEndOfGroup: boolean;
   objIdPresent?: boolean;
   defaultPriority?: boolean;
@@ -1311,7 +1354,7 @@ function getDatagramType(opts: {
   if (opts.isEndOfGroup) type |= MOQ_DATAGRAM_BIT_END_OF_GROUP;
   if (opts.objIdPresent === false) type |= MOQ_DATAGRAM_BIT_ZERO_OBJECT_ID;
   if (opts.defaultPriority) type |= MOQ_DATAGRAM_BIT_DEFAULT_PRIORITY;
-  if (opts.extensionsPresent) type |= MOQ_DATAGRAM_BIT_EXTENSIONS;
+  if (opts.propertiesPresent) type |= MOQ_DATAGRAM_BIT_PROPERTIES;
   if (!isMoqObjectDatagramType(type)) {
     throw new Error(`Datagram header to create type ${type} does not make sense`);
   }
@@ -1322,8 +1365,8 @@ export function isMoqObjectStreamHeaderType(type: number): boolean {
   if ((type & MOQ_SUBGROUP_BIT_REQUIRED) === 0) {
     return false; // bit 0x10 must be set
   }
-  if ((type & MOQ_SUBGROUP_FORBIDDEN_BITS) !== 0) {
-    return false; // bits 6-7 must be clear (form 0b00X1XXXX)
+  if ((type & ~0x7f) !== 0) {
+    return false; // bit 7 must be clear, form 0b0XX1XXXX
   }
   if ((type & MOQ_SUBGROUP_SUBGROUP_ID_MODE_MASK) >> 1 === 3) {
     return false; // reserved subgroup-id mode
@@ -1337,20 +1380,22 @@ export function moqDecodeStreamHeaderType(type: number): StreamHeaderOptions {
   }
   const mode = (type & MOQ_SUBGROUP_SUBGROUP_ID_MODE_MASK) >> 1;
   return {
-    extensionsPresent: (type & MOQ_SUBGROUP_BIT_EXTENSIONS) !== 0,
+    extensionsPresent: (type & MOQ_SUBGROUP_BIT_PROPERTIES) !== 0,
     isEndOfGroup: (type & MOQ_SUBGROUP_BIT_END_OF_GROUP) !== 0,
     subGroupIdPresent: mode === MOQ_SUBGROUP_ID_MODE_PRESENT,
     isSubgroupIdFirstObjectId: mode === MOQ_SUBGROUP_ID_MODE_ABSENT_FIRST_OBJ,
     isDefaultPriority: (type & MOQ_SUBGROUP_BIT_DEFAULT_PRIORITY) !== 0,
+    isFirstObject: (type & MOQ_SUBGROUP_BIT_FIRST_OBJECT) !== 0,
   };
 }
 
 function getSubgroupHeaderType(opts: {
-  extensionsPresent?: boolean;
+  propertiesPresent?: boolean;
   isEndOfGroup?: boolean;
   subGroupIdPresent?: boolean;
   isSubgroupIdFirstObjectId?: boolean;
   isDefaultPriority?: boolean;
+  isFirstObject?: boolean;
 }): number {
   let type = MOQ_SUBGROUP_BIT_REQUIRED;
   if (opts.subGroupIdPresent) {
@@ -1358,9 +1403,10 @@ function getSubgroupHeaderType(opts: {
   } else if (opts.isSubgroupIdFirstObjectId) {
     type |= MOQ_SUBGROUP_ID_MODE_ABSENT_FIRST_OBJ << 1;
   }
-  if (opts.extensionsPresent) type |= MOQ_SUBGROUP_BIT_EXTENSIONS;
+  if (opts.propertiesPresent) type |= MOQ_SUBGROUP_BIT_PROPERTIES;
   if (opts.isEndOfGroup) type |= MOQ_SUBGROUP_BIT_END_OF_GROUP;
   if (opts.isDefaultPriority) type |= MOQ_SUBGROUP_BIT_DEFAULT_PRIORITY;
+  if (opts.isFirstObject) type |= MOQ_SUBGROUP_BIT_FIRST_OBJECT;
   if (!isMoqObjectStreamHeaderType(type)) {
     throw new Error(`Subgroup header to create type ${type} does not make sense`);
   }

--- a/src/moq/varint.ts
+++ b/src/moq/varint.ts
@@ -7,61 +7,109 @@ LICENSE file in the root directory of this source tree.
 
 import { buffReadFrombyobReader, ReadStreamClosed } from './buffer_utils.js';
 
-const MAX_U6 = Math.pow(2, 6) - 1;
-const MAX_U14 = Math.pow(2, 14) - 1;
-const MAX_U30 = Math.pow(2, 30) - 1;
+// MoQ Transport draft-18 variable-length integer encoding (vi64).
+//
+// Unlike RFC9000 varints (where the two most-significant bits select a 1/2/4/8
+// byte length), draft-18 (§1.4.1) uses the number of leading 1 bits of the first
+// byte to indicate the encoded length in bytes (1..9). The value bits follow the
+// first 0 bit (or, for the 9-byte form, occupy the remaining 8 bytes).
+//
+//   Leading bits  Length  Usable bits  Range
+//   0             1       7            0-127
+//   10            2       14           0-16383
+//   110           3       21           ...
+//   1110          4       28
+//   11110         5       35
+//   111110        6       42
+//   1111110       7       49
+//   11111110      8       56
+//   11111111      9       64
+//
+// Non-minimal encodings are legal (draft-17 #1595): a value can be encoded using
+// more bytes than strictly required. Decoders MUST accept them; we always encode
+// using the minimal length.
+
+// We represent values as JS numbers, which are exact up to 2^53 - 1. Values that
+// require more precision are not produced by this application; encode throws on
+// overflow and decode converts via Number (losing precision only above 2^53).
 const MAX_U53 = Number.MAX_SAFE_INTEGER;
-// const MAX_U62 = 2n ** 62n - 1n
 
 export interface VarIntResult {
   num: number | undefined;
   byteLength: number;
 }
 
+// Usable value bits for a given encoded length (1..9).
+function usableBits(len: number): number {
+  return len === 9 ? 64 : 7 * len;
+}
+
+// Number of leading 1 bits in the first byte gives length - 1 (so length 1..9).
+function varIntLengthFromFirstByte(firstByte: number): number {
+  let ones = 0;
+  for (let mask = 0x80; (mask & firstByte) !== 0; mask >>= 1) {
+    ones++;
+  }
+  return ones + 1;
+}
+
 export function numberToVarInt(v: number): Uint8Array {
-  if (v <= MAX_U6) {
-    return setUint8(v);
-  } else if (v <= MAX_U14) {
-    return setUint16(v | 0x4000);
-  } else if (v <= MAX_U30) {
-    return setUint32(v | 0x80000000);
-  } else if (v <= MAX_U53) {
-    return setUint64(BigInt(v) | 0xc000000000000000n);
-  } else {
+  if (!Number.isInteger(v) || v < 0) {
+    throw new Error(`Cannot encode non integer or negative value as varint: ${v}`);
+  }
+  if (v > MAX_U53) {
     throw new Error(`overflow, value larger than 53-bits: ${v}`);
   }
+
+  // Pick the minimal length whose usable bits can represent the value.
+  let len = 1;
+  const big = BigInt(v);
+  while (len < 9 && big >= 1n << BigInt(usableBits(len))) {
+    len++;
+  }
+
+  const ret = new Uint8Array(len);
+  let tmp = big;
+  for (let i = len - 1; i >= 0; i--) {
+    ret[i] = Number(tmp & 0xffn);
+    tmp >>= 8n;
+  }
+  // OR the length-prefix bits into the first byte: (len-1) leading ones followed
+  // by a zero (for len 1..8), or 0xff for the 9-byte form.
+  const prefix = len === 9 ? 0xff : (0xff << (9 - len)) & 0xff;
+  ret[0] |= prefix;
+  return ret;
+}
+
+// Extract a vi64 value from `bytes` starting at `offset`, given the already
+// decoded `len`. The first byte's prefix bits are masked off.
+function extractValue(bytes: Uint8Array, offset: number, len: number): number {
+  let val = 0n;
+  if (len === 9) {
+    // First byte (0xff) is all prefix; value is the next 8 bytes.
+    for (let i = 1; i < 9; i++) {
+      val = (val << 8n) | BigInt(bytes[offset + i]);
+    }
+  } else {
+    const firstByteValueMask = (1 << (8 - len)) - 1;
+    val = BigInt(bytes[offset] & firstByteValueMask);
+    for (let i = 1; i < len; i++) {
+      val = (val << 8n) | BigInt(bytes[offset + i]);
+    }
+  }
+  return Number(val);
 }
 
 export function varIntToNumbeFromBuffer(buff: ArrayBuffer, offset?: number): VarIntResult {
-  let startOffset = 0;
-  if (typeof offset === 'number') {
-    startOffset = offset;
-  }
-  const ret: VarIntResult = { num: undefined, byteLength: 0 };
-  const size = (new DataView(buff, startOffset, 1).getUint8(0) & 0xc0) >> 6;
-  if (buff.byteLength < size + 1) {
+  const startOffset = typeof offset === 'number' ? offset : 0;
+  const bytes = new Uint8Array(buff);
+  const len = varIntLengthFromFirstByte(bytes[startOffset]);
+  if (buff.byteLength - startOffset < len) {
     throw new Error(
-      `Size of varint does NOT match (size: ${size}, buff.byteLength: ${buff.byteLength})`,
+      `Size of varint does NOT match (len: ${len}, available: ${buff.byteLength - startOffset})`,
     );
   }
-  if (size === 0) {
-    ret.num = new DataView(buff, startOffset, 1).getUint8(0) & 0x3f;
-    ret.byteLength = 1;
-  } else if (size === 1) {
-    ret.num = new DataView(buff, startOffset, 2).getUint16(0) & 0x3fff;
-    ret.byteLength = 2;
-  } else if (size === 2) {
-    ret.num = new DataView(buff, startOffset, 4).getUint32(0) & 0x3fffffff;
-    ret.byteLength = 4;
-  } else if (size === 3) {
-    ret.num = Number(
-      new DataView(buff, startOffset, 8).getBigUint64(0) & BigInt('0x3fffffffffffffff'),
-    );
-    ret.byteLength = 8;
-  } else {
-    throw new Error('Impossible size for varint');
-  }
-  return ret;
+  return { num: extractValue(bytes, startOffset, len), byteLength: len };
 }
 
 export async function varIntToNumberOrThrow(readableStream: ReadableStream): Promise<number> {
@@ -88,67 +136,23 @@ async function varIntToNumber(
   const ret = { eof: false, num: undefined, byteLength: 0 };
   const reader = readableStream.getReader({ mode: 'byob' });
   try {
-    let buff = new ArrayBuffer(8);
+    let buff = new ArrayBuffer(9);
     let retData = await buffReadFrombyobReader(reader, buff, 0, 1);
-    ret.byteLength = ret.byteLength + 1;
+    ret.byteLength = 1;
     ret.eof = retData.eof;
     if (!ret.eof) {
       buff = retData.buff;
-      const size = (new DataView(buff, 0, 1).getUint8(0) & 0xc0) >> 6;
-      if (size === 0) {
-        ret.eof = retData.eof;
-        ret.num = new DataView(buff, 0, 1).getUint8(0) & 0x3f;
-      } else if (size === 1) {
-        retData = await buffReadFrombyobReader(reader, buff, 1, 1);
-        ret.byteLength = ret.byteLength + 1;
+      const len = varIntLengthFromFirstByte(new DataView(buff, 0, 1).getUint8(0));
+      if (len > 1) {
+        retData = await buffReadFrombyobReader(reader, buff, 1, len - 1);
         buff = retData.buff;
         ret.eof = retData.eof;
-        ret.num = new DataView(buff, 0, 2).getUint16(0) & 0x3fff;
-      } else if (size === 2) {
-        retData = await buffReadFrombyobReader(reader, buff, 1, 3);
-        ret.byteLength = ret.byteLength + 3;
-        buff = retData.buff;
-        ret.eof = retData.eof;
-        ret.num = new DataView(buff, 0, 4).getUint32(0) & 0x3fffffff;
-      } else if (size === 3) {
-        retData = await buffReadFrombyobReader(reader, buff, 1, 7);
-        ret.byteLength = ret.byteLength + 7;
-        buff = retData.buff;
-        ret.eof = retData.eof;
-        ret.num = Number(new DataView(buff, 0, 8).getBigUint64(0) & BigInt('0x3fffffffffffffff'));
-      } else {
-        throw new Error('Impossible size for varint');
+        ret.byteLength = len;
       }
+      ret.num = extractValue(new Uint8Array(buff), 0, len);
     }
   } finally {
     reader.releaseLock();
   }
-  return ret;
-}
-
-function setUint8(v: number): Uint8Array {
-  const ret = new Uint8Array(1);
-  ret[0] = v;
-  return ret;
-}
-
-function setUint16(v: number): Uint8Array {
-  const ret = new Uint8Array(2);
-  const view = new DataView(ret.buffer);
-  view.setUint16(0, v);
-  return ret;
-}
-
-function setUint32(v: number): Uint8Array {
-  const ret = new Uint8Array(4);
-  const view = new DataView(ret.buffer);
-  view.setUint32(0, v);
-  return ret;
-}
-
-function setUint64(v: bigint): Uint8Array {
-  const ret = new Uint8Array(8);
-  const view = new DataView(ret.buffer);
-  view.setBigUint64(0, v);
   return ret;
 }

--- a/tests/moq.test.ts
+++ b/tests/moq.test.ts
@@ -39,13 +39,54 @@ function fakeMoq(opts: { hangStream?: boolean; hangClose?: boolean } = {}) {
   return { moq, writes };
 }
 
+// A minimal stand-in for a WebTransport bidirectional request stream (draft-19
+// runs each PUBLISH / SUBSCRIBE on its own bidi stream). Records cancel/close so
+// teardown behaviour can be asserted.
+function fakeBidiStream() {
+  const calls = { cancelled: 0, closed: 0 };
+  const writer = {
+    write: () => Promise.resolve(),
+    close: () => Promise.resolve(),
+    ready: Promise.resolve(),
+    releaseLock: () => {},
+  };
+  const stream: any = {
+    writable: {
+      getWriter: () => writer,
+      close: () => {
+        calls.closed++;
+        return Promise.resolve();
+      },
+    },
+    readable: {
+      cancel: () => {
+        calls.cancelled++;
+        return Promise.resolve();
+      },
+    },
+    _calls: calls,
+  };
+  return stream;
+}
+
 function makeTrack(
   moq: any,
   mapping: MoqMapping,
   maxInFlight = 1000,
   maxOpenStreams = 1000,
 ): Track {
-  return new Track(moq, ['vc'], 'v0', 2, 7, maxInFlight, maxOpenStreams, undefined, mapping);
+  return new Track(
+    moq,
+    ['vc'],
+    'v0',
+    2,
+    7,
+    maxInFlight,
+    maxOpenStreams,
+    undefined,
+    mapping,
+    fakeBidiStream(),
+  );
 }
 
 describe('Track sequencing', () => {
@@ -192,10 +233,19 @@ describe('Subscription', () => {
   it('reports its identity and forwards received objects to the callback', async () => {
     const { moq } = fakeMoq();
     const received: Array<{ length?: number }> = [];
-    const sub = new Subscription(moq, ['vc'], 'a0', 4, 9, 'secret', async (_r, _e, length) => {
-      received.push({ length });
-      return true; // EOF
-    });
+    const sub = new Subscription(
+      moq,
+      ['vc'],
+      'a0',
+      4,
+      9,
+      'secret',
+      async (_r, _e, length) => {
+        received.push({ length });
+        return true; // EOF
+      },
+      fakeBidiStream(),
+    );
 
     expect(sub.getInfo()).toEqual({
       namespace: ['vc'],
@@ -209,12 +259,16 @@ describe('Subscription', () => {
     expect(received).toEqual([{ length: 10 }]);
   });
 
-  it('unsubscribe sends UNSUBSCRIBE once and is idempotent', async () => {
-    const { moq, writes } = fakeMoq();
-    const sub = new Subscription(moq, ['vc'], 'a0', 4, 9, undefined, () => false);
+  it('unsubscribe closes the request stream once and is idempotent', async () => {
+    const { moq } = fakeMoq();
+    const stream = fakeBidiStream();
+    const sub = new Subscription(moq, ['vc'], 'a0', 4, 9, undefined, () => false, stream);
+    // draft-19 has no UNSUBSCRIBE message: cancel readable (STOP_SENDING) + close
+    // writable (FIN) exactly once, even across repeated calls.
     await sub.unsubscribe();
     await sub.unsubscribe(); // no-op the second time
-    expect(writes.length).toBe(1);
+    expect(stream._calls.cancelled).toBe(1);
+    expect(stream._calls.closed).toBe(1);
   });
 });
 
@@ -292,8 +346,9 @@ describe('Moq.init ALPN negotiation', () => {
     constructor(url: string, options: any) {
       captured = { url, options };
     }
-    async createBidirectionalStream() {
-      return { readable: {}, writable: {} };
+    // draft-19 opens a unidirectional control stream (SETUP) rather than a bidi one.
+    async createUnidirectionalStream() {
+      return {};
     }
     close() {}
   }

--- a/tests/moqt.test.ts
+++ b/tests/moqt.test.ts
@@ -19,41 +19,36 @@ import {
   moqParseMsg,
   moqParseObjectHeader,
   moqParseObjectFromSubgroupHeader,
-  moqSendClientSetup,
+  moqSendSetup,
   moqSendSubscribe,
   moqSendSubscribeOk,
   moqSendPublish,
   moqSendPublishDone,
   moqSendRequestOk,
   moqSendRequestError,
-  moqSendUnSubscribe,
   moqSendSubgroupHeader,
   moqSendObjectSubgroupToWriter,
   moqSendObjectEndOfGroupToWriter,
   moqSendObjectPerDatagramToWriter,
-  MOQ_MESSAGE_CLIENT_SETUP,
-  MOQ_MESSAGE_SERVER_SETUP,
+  MOQ_MESSAGE_SETUP,
   MOQ_MESSAGE_SUBSCRIBE,
   MOQ_MESSAGE_SUBSCRIBE_OK,
   MOQ_MESSAGE_PUBLISH,
-  MOQ_MESSAGE_PUBLISH_OK,
   MOQ_MESSAGE_PUBLISH_DONE,
   MOQ_MESSAGE_REQUEST_OK,
   MOQ_MESSAGE_REQUEST_ERROR,
-  MOQ_MESSAGE_UNSUBSCRIBE,
   MOQ_PARAMETER_SUBSCRIPTION_FILTER,
   MOQ_FORWARD_TRUE,
   MOQ_OBJ_STATUS_END_OF_GROUP,
   MOQ_EXT_HEADER_TYPE_MOQMI_MEDIA_TYPE,
-  MOQ_EXT_HEADER_TYPE_MOQMI_VIDEO_H264_IN_AVCC_METADATA,
+  MOQ_SETUP_OPTION_MOQT_IMPLEMENTATION,
+  MOQ_IMPLEMENTATION_NAME,
 } from '../src/moq/moqt.js';
-import { numberToVarInt, varIntToNumbeFromBuffer } from '../src/moq/varint.js';
-import { numberTo2BytesArray } from '../src/moq/byte_utils.js';
-import { concatBuffer, getArrayBufferByteLength } from '../src/moq/buffer_utils.js';
+import { concatBuffer } from '../src/moq/buffer_utils.js';
 
-// The subgroup header type the encoder always emits (draft-16, no FIRST_OBJECT):
-// extensions present + subgroup id present => 0x10 | 0x01 | 0x04 = 0x15
-const SUBGROUP_HEADER_TYPE = 0x15;
+// The subgroup header type the encoder always emits:
+// props present + subgroup id present + first object => 0x10|0x01|0x04|0x40 = 0x55
+const SUBGROUP_HEADER_TYPE = 0x55;
 
 // --- Test doubles ------------------------------------------------------------
 
@@ -70,7 +65,11 @@ function createCaptureStream() {
       return Promise.resolve();
     },
   };
-  const writerStream = { getWriter: () => writer };
+  const writerStream = {
+    getWriter() {
+      return writer;
+    },
+  };
   return {
     writerStream: writerStream as unknown as WritableStream<Uint8Array>,
     writer: writer as unknown as WritableStreamDefaultWriter<Uint8Array>,
@@ -78,6 +77,7 @@ function createCaptureStream() {
   };
 }
 
+// A ReadableStream-like double exposing a BYOB reader over a fixed byte array.
 function createByobReadable(bytes: Uint8Array): ReadableStream<Uint8Array> {
   let pos = 0;
   const stream = {
@@ -105,22 +105,26 @@ function createByobReadable(bytes: Uint8Array): ReadableStream<Uint8Array> {
   return stream as unknown as ReadableStream<Uint8Array>;
 }
 
-// Frame a control message: [type varint][u16 length][...body].
-function frame(type: number, ...parts: (Uint8Array | ArrayBuffer)[]): Uint8Array {
-  const len = getArrayBufferByteLength(parts);
-  return concatBuffer([numberToVarInt(type), numberTo2BytesArray(len, false), ...parts]);
-}
+const decodeStr = (b: Uint8Array | ArrayBuffer) =>
+  new TextDecoder().decode(b instanceof Uint8Array ? b : new Uint8Array(b));
 
 // --- Pure helpers ------------------------------------------------------------
 
 describe('moqt pure helpers', () => {
-  it('getTrackFullName / getFullTrackName / moqCreateKvPair', () => {
+  it('getTrackFullName concatenates namespace and track name', () => {
     expect(getTrackFullName('ns', 'track')).toBe('nstrack');
+  });
+
+  it('getFullTrackName formats a tuple namespace', () => {
     expect(getFullTrackName(['a', 'b'], 'name')).toBe('[a/b]/name');
+    expect(getFullTrackName([], 'name')).toBe('[]/name');
+  });
+
+  it('moqCreateKvPair builds a {name, val} pair', () => {
     expect(moqCreateKvPair(3, 7)).toEqual({ name: 3, val: 7 });
   });
 
-  it('classifies datagram and subgroup stream types (draft-16 bit layout)', () => {
+  it('classifies datagram and subgroup stream types (draft-18 bit layout)', () => {
     expect(isMoqObjectDatagramType(0x0)).toBe(true);
     expect(isMoqObjectDatagramType(0x1)).toBe(true);
     expect(isMoqObjectDatagramType(0x20)).toBe(true);
@@ -130,7 +134,6 @@ describe('moqt pure helpers', () => {
     expect(isMoqObjectStreamHeaderType(SUBGROUP_HEADER_TYPE)).toBe(true);
     expect(isMoqObjectStreamHeaderType(0x1)).toBe(false);
     expect(isMoqObjectStreamHeaderType(0x16)).toBe(false); // reserved subgroup-id mode
-    expect(isMoqObjectStreamHeaderType(0x50)).toBe(false); // draft-16 has no 0x50 range
   });
 
   it('getAuthInfofromParameters returns undefined when there is no auth token', () => {
@@ -139,7 +142,7 @@ describe('moqt pure helpers', () => {
   });
 });
 
-describe('moqDecodeDatagramType (draft-16)', () => {
+describe('moqDecodeDatagramType (draft-18)', () => {
   it('decodes a plain object datagram', () => {
     expect(moqDecodeDatagramType(0x0)).toEqual({
       isStatus: false,
@@ -150,12 +153,17 @@ describe('moqDecodeDatagramType (draft-16)', () => {
     });
   });
 
-  it('decodes extensions + end-of-group, and status', () => {
-    const d = moqDecodeDatagramType(0x03); // EXTENSIONS | END_OF_GROUP
+  it('decodes the properties + end-of-group bits', () => {
+    const d = moqDecodeDatagramType(0x03); // PROPERTIES | END_OF_GROUP
     expect(d.extensionsPresent).toBe(true);
     expect(d.isEndOfGroup).toBe(true);
-    const s = moqDecodeDatagramType(0x20);
-    expect(s.isStatus).toBe(true);
+    expect(d.isStatus).toBe(false);
+  });
+
+  it('decodes a status datagram', () => {
+    const d = moqDecodeDatagramType(0x20);
+    expect(d.isStatus).toBe(true);
+    expect(d.isObjIdPresent).toBe(true);
   });
 
   it('throws on a non-datagram type', () => {
@@ -163,18 +171,19 @@ describe('moqDecodeDatagramType (draft-16)', () => {
   });
 });
 
-describe('moqDecodeStreamHeaderType (draft-16)', () => {
-  it('decodes the canonical subgroup header type 0x15', () => {
+describe('moqDecodeStreamHeaderType (draft-18)', () => {
+  it('decodes the canonical subgroup header type 0x55', () => {
     expect(moqDecodeStreamHeaderType(SUBGROUP_HEADER_TYPE)).toEqual({
       extensionsPresent: true,
       isEndOfGroup: false,
       subGroupIdPresent: true,
       isSubgroupIdFirstObjectId: false,
       isDefaultPriority: false,
+      isFirstObject: true,
     });
   });
 
-  it('throws on non-stream-header / reserved types', () => {
+  it('throws on non-stream-header types and reserved subgroup-id mode', () => {
     expect(() => moqDecodeStreamHeaderType(0x1)).toThrow();
     expect(() => moqDecodeStreamHeaderType(0x16)).toThrow();
   });
@@ -186,7 +195,6 @@ describe('moqCreate / moqCloseWrttingStreams', () => {
   it('moqCreate returns a clean initial state', () => {
     expect(moqCreate()).toEqual({
       wt: null,
-      controlStream: null,
       controlWriter: null,
       controlReader: null,
       multiObjectWritter: {},
@@ -212,25 +220,23 @@ describe('moqCreate / moqCloseWrttingStreams', () => {
 // --- Control message round trips via moqParseMsg -----------------------------
 
 describe('control message round trips via moqParseMsg', () => {
-  it('CLIENT_SETUP emits the CLIENT_SETUP type (no version field in draft-16)', async () => {
+  it('SETUP round-trips and carries the implementation option', async () => {
     const cap = createCaptureStream();
-    await moqSendClientSetup(cap.writerStream);
-    const bytes = cap.getBytes();
-    expect(bytes[0]).toBe(MOQ_MESSAGE_CLIENT_SETUP); // 0x20 fits one varint byte
-  });
-
-  it('SERVER_SETUP parses (no version, empty params)', async () => {
-    const parsed = await moqParseMsg(
-      createByobReadable(frame(MOQ_MESSAGE_SERVER_SETUP, numberToVarInt(0))),
+    await moqSendSetup(cap.writerStream);
+    const parsed = await moqParseMsg(createByobReadable(cap.getBytes()));
+    expect(parsed.type).toBe(MOQ_MESSAGE_SETUP);
+    const impl = parsed.data.options.find(
+      (o: any) => o.name === MOQ_SETUP_OPTION_MOQT_IMPLEMENTATION,
     );
-    expect(parsed.type).toBe(MOQ_MESSAGE_SERVER_SETUP);
-    expect(parsed.data.parameters).toEqual([]);
+    expect(impl).toBeDefined();
+    expect(decodeStr(impl.val)).toBe(MOQ_IMPLEMENTATION_NAME);
   });
 
-  it('SUBSCRIBE round-trips, including the filter and auth token', async () => {
+  it('SUBSCRIBE round-trips, including the largest-object filter and auth token', async () => {
     const cap = createCaptureStream();
     await moqSendSubscribe(cap.writerStream, 42, ['ns', 'a'], 'video', 'secret');
     const parsed = await moqParseMsg(createByobReadable(cap.getBytes()));
+
     expect(parsed.type).toBe(MOQ_MESSAGE_SUBSCRIBE);
     expect(parsed.data.requestId).toBe(42);
     expect(parsed.data.namespace).toEqual(['ns', 'a']);
@@ -251,18 +257,18 @@ describe('control message round trips via moqParseMsg', () => {
 
   it('SUBSCRIBE_OK round-trips with a largest-object location', async () => {
     const cap = createCaptureStream();
-    await moqSendSubscribeOk(cap.writerStream, 7, 99, 5, 3);
+    await moqSendSubscribeOk(cap.writerStream, 99, 5, 3);
     const parsed = await moqParseMsg(createByobReadable(cap.getBytes()));
     expect(parsed.type).toBe(MOQ_MESSAGE_SUBSCRIBE_OK);
-    expect(parsed.data.requestId).toBe(7);
     expect(parsed.data.trackAlias).toBe(99);
     expect(parsed.data.last).toEqual({ group: 5, obj: 3 });
   });
 
   it('SUBSCRIBE_OK without a location omits `last`', async () => {
     const cap = createCaptureStream();
-    await moqSendSubscribeOk(cap.writerStream, 7, 99);
+    await moqSendSubscribeOk(cap.writerStream, 99);
     const parsed = await moqParseMsg(createByobReadable(cap.getBytes()));
+    expect(parsed.data.trackAlias).toBe(99);
     expect(parsed.data.last).toBeUndefined();
   });
 
@@ -276,24 +282,14 @@ describe('control message round trips via moqParseMsg', () => {
     expect(parsed.data.trackName).toBe('name');
     expect(parsed.data.trackAlias).toBe(77);
     expect(getAuthInfofromParameters(parsed.data.parameters)).toBe('secret');
-    expect(parsed.data.extensions).toEqual([]);
-  });
-
-  it('PUBLISH_OK parses', async () => {
-    const parsed = await moqParseMsg(
-      createByobReadable(frame(MOQ_MESSAGE_PUBLISH_OK, numberToVarInt(3), numberToVarInt(0))),
-    );
-    expect(parsed.type).toBe(MOQ_MESSAGE_PUBLISH_OK);
-    expect(parsed.data.reqId).toBe(3);
-    expect(parsed.data.parameters).toEqual([]);
+    expect(parsed.data.properties).toEqual([]);
   });
 
   it('PUBLISH_DONE round-trips', async () => {
     const cap = createCaptureStream();
-    await moqSendPublishDone(cap.writerStream, 8, 2, 16, 'bye');
+    await moqSendPublishDone(cap.writerStream, 2, 16, 'bye');
     const parsed = await moqParseMsg(createByobReadable(cap.getBytes()));
     expect(parsed.type).toBe(MOQ_MESSAGE_PUBLISH_DONE);
-    expect(parsed.data.requestId).toBe(8);
     expect(parsed.data.statusCode).toBe(2);
     expect(parsed.data.streamCount).toBe(16);
     expect(parsed.data.errorReason).toBe('bye');
@@ -301,30 +297,21 @@ describe('control message round trips via moqParseMsg', () => {
 
   it('REQUEST_OK round-trips', async () => {
     const cap = createCaptureStream();
-    await moqSendRequestOk(cap.writerStream, 12);
+    await moqSendRequestOk(cap.writerStream);
     const parsed = await moqParseMsg(createByobReadable(cap.getBytes()));
     expect(parsed.type).toBe(MOQ_MESSAGE_REQUEST_OK);
-    expect(parsed.data.requestId).toBe(12);
     expect(parsed.data.parameters).toEqual([]);
+    expect(parsed.data.properties).toEqual([]);
   });
 
   it('REQUEST_ERROR round-trips', async () => {
     const cap = createCaptureStream();
-    await moqSendRequestError(cap.writerStream, 11, 3, 'nope');
+    await moqSendRequestError(cap.writerStream, 3, 'nope');
     const parsed = await moqParseMsg(createByobReadable(cap.getBytes()));
     expect(parsed.type).toBe(MOQ_MESSAGE_REQUEST_ERROR);
-    expect(parsed.data.requestId).toBe(11);
     expect(parsed.data.errorCode).toBe(3);
     expect(parsed.data.retryInterval).toBe(0);
     expect(parsed.data.errorReason).toBe('nope');
-  });
-
-  it('UNSUBSCRIBE round-trips', async () => {
-    const cap = createCaptureStream();
-    await moqSendUnSubscribe(cap.writerStream, 1234);
-    const parsed = await moqParseMsg(createByobReadable(cap.getBytes()));
-    expect(parsed.type).toBe(MOQ_MESSAGE_UNSUBSCRIBE);
-    expect(parsed.data.requestId).toBe(1234);
   });
 
   it('rejects a truncated stream', async () => {
@@ -334,11 +321,12 @@ describe('control message round trips via moqParseMsg', () => {
 
 // --- Object/datagram path ----------------------------------------------------
 
-describe('object and datagram headers (draft-16)', () => {
+describe('object and datagram headers (draft-18)', () => {
   it('subgroup header round-trips through moqParseObjectHeader', async () => {
     const cap = createCaptureStream();
     await moqSendSubgroupHeader(cap.writer, 50, 9, 0x0a);
     const parsed = await moqParseObjectHeader(createByobReadable(cap.getBytes()));
+
     expect(parsed.type).toBe(SUBGROUP_HEADER_TYPE);
     expect(parsed.trackAlias).toBe(50);
     expect(parsed.groupSeq).toBe(9);
@@ -349,7 +337,8 @@ describe('object and datagram headers (draft-16)', () => {
 
   it('subgroup object round-trips through moqParseObjectFromSubgroupHeader', async () => {
     const cap = createCaptureStream();
-    await moqSendObjectSubgroupToWriter(cap.writer, 4, new Uint8Array([1, 2, 3]), []);
+    const payload = new Uint8Array([1, 2, 3]);
+    await moqSendObjectSubgroupToWriter(cap.writer, 4, payload, []);
     const parsed = await moqParseObjectFromSubgroupHeader(
       createByobReadable(cap.getBytes()),
       SUBGROUP_HEADER_TYPE,
@@ -371,7 +360,7 @@ describe('object and datagram headers (draft-16)', () => {
     expect(parsed.status).toBe(MOQ_OBJ_STATUS_END_OF_GROUP);
   });
 
-  it('per-datagram object (with extensions) round-trips its header', async () => {
+  it('per-datagram object (with properties) round-trips its header', async () => {
     const cap = createCaptureStream();
     const ext = [moqCreateKvPair(MOQ_EXT_HEADER_TYPE_MOQMI_MEDIA_TYPE, 5)];
     await moqSendObjectPerDatagramToWriter(
@@ -385,6 +374,7 @@ describe('object and datagram headers (draft-16)', () => {
       false,
     );
     const parsed = await moqParseObjectHeader(createByobReadable(cap.getBytes()));
+
     expect(parsed.trackAlias).toBe(12);
     expect(parsed.groupSeq).toBe(3);
     expect(parsed.objSeq).toBe(4);
@@ -396,26 +386,7 @@ describe('object and datagram headers (draft-16)', () => {
   });
 
   it('moqParseObjectHeader throws on an unknown object type', async () => {
+    const { numberToVarInt } = await import('../src/moq/varint.js');
     await expect(moqParseObjectHeader(createByobReadable(numberToVarInt(0x7f)))).rejects.toThrow();
-  });
-
-  // Regression: odd-typed extension header values must decode to an ArrayBuffer,
-  // since the MoQMI packager reads them via varIntToNumbeFromBuffer / DataView.
-  it('decodes odd-typed extension header values as an ArrayBuffer', async () => {
-    const cap = createCaptureStream();
-    const blob = concatBuffer([numberToVarInt(7), numberToVarInt(258)]); // two varints
-    const ext = [moqCreateKvPair(MOQ_EXT_HEADER_TYPE_MOQMI_VIDEO_H264_IN_AVCC_METADATA, blob)];
-    await moqSendObjectSubgroupToWriter(cap.writer, 0, new Uint8Array([1]), ext);
-
-    const parsed = await moqParseObjectFromSubgroupHeader(
-      createByobReadable(cap.getBytes()),
-      SUBGROUP_HEADER_TYPE,
-    );
-    expect(parsed.extensionHeaders).toHaveLength(1);
-    const val = parsed.extensionHeaders[0].val as ArrayBuffer;
-    expect(val instanceof ArrayBuffer).toBe(true);
-    const r0 = varIntToNumbeFromBuffer(val, 0);
-    expect(r0.num).toBe(7);
-    expect(varIntToNumbeFromBuffer(val, r0.byteLength).num).toBe(258);
   });
 });

--- a/tests/varint.test.ts
+++ b/tests/varint.test.ts
@@ -12,8 +12,14 @@ function roundTrip(value: number) {
   return varIntToNumbeFromBuffer(encoded.buffer as ArrayBuffer, 0);
 }
 
-describe('varint', () => {
-  it('encodes small values (<= 6 bits) into a single byte', () => {
+function hex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+describe('varint (draft-18 vi64, leading-1-bits)', () => {
+  it('encodes 7-bit values into a single byte', () => {
     const encoded = numberToVarInt(5);
     expect(encoded.byteLength).toBe(1);
     expect(roundTrip(5)).toEqual({ num: 5, byteLength: 1 });
@@ -25,21 +31,36 @@ describe('varint', () => {
     expect(roundTrip(1000)).toEqual({ num: 1000, byteLength: 2 });
   });
 
-  it('encodes 30-bit values into 4 bytes', () => {
+  it('encodes 21-bit values into 3 bytes', () => {
     const encoded = numberToVarInt(100000);
-    expect(encoded.byteLength).toBe(4);
-    expect(roundTrip(100000)).toEqual({ num: 100000, byteLength: 4 });
+    expect(encoded.byteLength).toBe(3);
+    expect(roundTrip(100000)).toEqual({ num: 100000, byteLength: 3 });
   });
 
-  it('encodes 53-bit values into 8 bytes', () => {
+  it('encodes 2^40 into 6 bytes', () => {
     const value = 2 ** 40;
     const encoded = numberToVarInt(value);
-    expect(encoded.byteLength).toBe(8);
-    expect(roundTrip(value)).toEqual({ num: value, byteLength: 8 });
+    expect(encoded.byteLength).toBe(6);
+    expect(roundTrip(value)).toEqual({ num: value, byteLength: 6 });
+  });
+
+  it('matches the draft-18 §1.4.1 minimal-encoding example vectors', () => {
+    // 0x25 -> 37, 0xbbbd -> 15293, 0xed7f3e7d -> 226442877
+    expect(hex(numberToVarInt(37))).toBe('25');
+    expect(hex(numberToVarInt(15293))).toBe('bbbd');
+    expect(hex(numberToVarInt(226442877))).toBe('ed7f3e7d');
+  });
+
+  it('decodes non-minimal encodings (0x8025 -> 37)', () => {
+    const nonMinimal = new Uint8Array([0x80, 0x25]);
+    expect(varIntToNumbeFromBuffer(nonMinimal.buffer as ArrayBuffer, 0)).toEqual({
+      num: 37,
+      byteLength: 2,
+    });
   });
 
   it('round-trips the boundary values for each varint size', () => {
-    for (const value of [0, 63, 64, 16383, 16384, 1073741823]) {
+    for (const value of [0, 127, 128, 16383, 16384, 2097151, 2097152, 268435455]) {
       expect(roundTrip(value).num).toBe(value);
     }
   });


### PR DESCRIPTION
Rework the MoQ wire protocol and session layer from IETF draft-ietf-moq-transport-16 to draft-18. This covers the three 'whole-wire' breaking changes introduced across draft-17/18:

- varint.ts: replace the RFC9000 2-MSB variable-length integer with the draft-18 leading-1-bits (vi64) encoding (1-9 bytes, 64-bit, non-minimal encodings accepted).
- moqt.ts: merge CLIENT_SETUP/SERVER_SETUP into a single SETUP (0x2F00); frame control over a unidirectional stream; drop UNSUBSCRIBE / FETCH_CANCEL / MAX_REQUEST_ID; PUBLISH ack via REQUEST_OK; widen the SUBGROUP_HEADER type form for the FIRST_OBJECT bit; rename Extension Headers -> Properties.
- moq.ts: each request (PUBLISH/SUBSCRIBE) now runs on its own bidirectional stream with a per-request response loop; the control channel is a pair of unidirectional streams; cancellation uses QUIC stream primitives (STOP_SENDING/FIN) instead of dedicated messages; keep-alive sends a no-op REQUEST_UPDATE. Public Moq/Track/Subscription API preserved.

ALPN token 'moqt-18'. Build, tests (83), lint and format all pass.